### PR TITLE
feat: add cates-optimize tool and experimental cache/output-shaping mode

### DIFF
--- a/CATES-v1.0.md
+++ b/CATES-v1.0.md
@@ -200,6 +200,13 @@ Rules are identified by a prefix indicating their domain and a numeric sequence:
 | EDC | Editor Configuration |
 | AGT | Subagent Definitions |
 | CMD | Slash Commands |
+| CS | Cache-Shaping (🧪 Experimental) |
+| OS | Output-Shaping (🧪 Experimental) |
+
+Rule IDs MAY carry a status marker. A 🧪 **Experimental** marker denotes a
+non-normative rule: it is Informative, carries zero scoring weight, is excluded
+from all conformance classes and profiles, and is exempt from this document's
+versioning guarantees (it MAY change or be removed in a minor revision).
 
 ### 4.3 Severity Levels
 
@@ -222,6 +229,16 @@ Rules are identified by a prefix indicating their domain and a numeric sequence:
 ### 4.5 Normative vs. Informative Content
 
 Sections and annexes are marked as either **Normative** (requirements that MUST be satisfied for conformance) or **Informative** (guidance, examples, and rationale that aid understanding but are not required).
+
+A third status, **Experimental (non-normative)**, applies to content under active
+exploration (currently the §9.9 Cache-Shaping and §9.10 Output-Shaping rules).
+Experimental content is a special case of Informative: it MUST NOT affect a
+repository's score, grade, or conformance level; it is excluded from all
+conformance classes and profiles and from CI gates; and it is exempt from the
+standard's versioning guarantees. Tools MUST keep experimental findings in a
+separate, clearly-labeled channel and MUST require explicit opt-in to produce
+them. Experimental rules graduate to Normative only via a major revision (§14.2),
+because admitting them to scoring changes existing results.
 
 ---
 
@@ -283,6 +300,42 @@ CATES recognizes that security failures frequently manifest as token waste:
 | Injection vulnerabilities | Adversarial payloads expand context → inflated billing |
 
 Security controls frequently improve token efficiency. However, CATES acknowledges exceptions where security measures add token overhead (e.g., prompt protection directives consume ~20 tokens). In such cases, security MUST take precedence over efficiency.
+
+### 5.4 Token Cost Vector (Experimental — Informative)
+
+> 🧪 **Experimental.** This subsection motivates the §9.9/§9.10 experimental
+> rules and is non-normative. It does not change any measurement or score.
+
+The normative model above optimizes **input authoring** (shrinking always-loaded
+config). Under token-based billing, input is only one of three token classes, and
+not the most expensive. A fuller cost vector is:
+
+| Token class | Relative cost | Driver visible in static config? |
+|-------------|---------------|----------------------------------|
+| Cached input | ≈ 0.1× (≈ 90% off) | Partly — **prefix stability** |
+| Uncached input | 1× (baseline) | Yes — config size/scope (the §9.2 rules) |
+| Cache write | ≈ 1.25–2× | Partly |
+| Output | ≈ 2–5× | Partly — output **contract** |
+
+*(Illustrative ratios — Claude-family, 2026; the structural ordering
+`output ≫ uncached-input ≫ cached-input` is stable across vendors, but verify
+exact multipliers per model/provider before quoting them.)*
+
+Two orthogonal, statically-detectable axes follow:
+
+- **Prefix stability (cache).** A request hits the prompt cache only when its
+  leading tokens are byte-identical to a prior request. Volatile tokens (dates,
+  UUIDs, SHAs) or variable-before-static ordering in the always-loaded prefix
+  bust the cache every call. See §9.9.
+- **Output contract.** Because output is the priciest class, config that fails to
+  bound output — or mandates full-file rewrites, unconditional verbose reasoning,
+  or echoing — provably inflates the most expensive tokens. See §9.10.
+
+Both axes can be improved **without changing any instruction's meaning**, so
+functionality is preserved by construction. Actual cache-hit %, output:input
+ratio, and reasoning-token share are **runtime** signals outside CATES's
+static scope (§11) and are deferred to a future Informative annex on
+Token-Economics Telemetry.
 
 ---
 
@@ -431,6 +484,10 @@ CATES defines three conformance classes, applicable to different subjects:
 | **Repository Conformance** | A source code repository | The repository's configuration files satisfy all applicable rules at the claimed level |
 | **Tool Conformance** | An analysis tool | The tool correctly implements CATES measurement and produces findings consistent with the reference implementation |
 | **Organizational Conformance** | An enterprise program | The organization has governance, measurement, and remediation processes aligned with CATES |
+
+Experimental rules (§9.9, §9.10) are excluded from every conformance class and
+profile. A repository's conformance level MUST be determined from Normative rules
+only; experimental findings never cause a conformance failure.
 
 ### 8.2 Conformance Profiles
 
@@ -1059,6 +1116,148 @@ Custom subagents and slash commands are distinct configuration surfaces: a subag
 
 ---
 
+### 9.9 Cache-Shaping Rules (🧪 Experimental — Informative)
+
+> 🧪 **Experimental — Informative.** The rules in §9.9 and §9.10 are
+> non-normative: zero scoring weight, excluded from conformance and CI gates,
+> off by default, and SemVer-exempt (§14.2). Severities are **advisory** (they aid
+> prioritization but never gate or score). Prefix `CS`. See §5.4 for motivation.
+
+These rules flag statically-detectable config patterns that wreck prompt-cache
+hit-rate by destabilizing the cacheable prefix. They do not measure runtime cache
+behavior (§11).
+
+#### CS001 — Volatile Tokens in Always-Loaded Config
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | cache-shaping (experimental) |
+| Severity | High (advisory) |
+| Applicability | Always-loaded configuration |
+
+**Detection:** An always-loaded file embeds volatile values — timestamps/dates, UUIDs, build numbers, git SHAs — or a "current date/time" directive.
+
+**Rationale:** Volatile tokens in the prefix change between calls, so every request misses the cache and pays full (≈10×) input price on the whole prefix.
+
+**Remediation:** Move volatile values out of the always-loaded prefix; supply them via tool inputs at the end of context.
+
+#### CS002 — Dynamic-Before-Static Ordering
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | cache-shaping (experimental) |
+| Severity | Medium (advisory) |
+| Applicability | Prompt/instruction templates |
+
+**Detection:** A variable placeholder (`${…}`, `{{…}}`) or `@include` appears ahead of a large static block, minimizing the cacheable prefix.
+
+**Remediation:** Put stable, static content first; place variable/dynamic content at the end.
+
+#### CS003 — Non-Deterministic Context Directive
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | cache-shaping (experimental) |
+| Severity | Medium (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Instructions inject live/volatile state into the preamble (e.g. "always include current git status / latest logs / today's date").
+
+**Remediation:** Fetch volatile state on-demand via tools rather than embedding it in always-loaded instructions.
+
+#### CS004 — Unstable Tool/Context Ordering
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | cache-shaping (experimental) |
+| Severity | Low (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Directives that randomize or re-sort tool lists / retrieved context per call.
+
+**Remediation:** Keep tool and context ordering stable and deterministic across calls.
+
+#### CS005 — Fragmented Preamble (No Shared Prelude)
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | cache-shaping (experimental) |
+| Severity | Info (advisory) |
+| Applicability | Multiple configuration files |
+
+**Detection:** High cross-file near-duplication of preamble that could be one shared, cacheable prelude (correlates with TE006).
+
+**Remediation:** Hoist the shared preamble into a single, stable, precedence-appropriate prelude.
+
+### 9.10 Output-Shaping Rules (🧪 Experimental — Informative)
+
+> 🧪 **Experimental — Informative.** See the §9.9 banner. Prefix `OS`. Output is
+> the priciest token class (≈ 2–5× input), so these advisory rules target config
+> that provably inflates output. Overlaps with TE004/CNF002 are intentional and
+> may merge at graduation.
+
+#### OS001 — Missing Output Contract
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | output-shaping (experimental) |
+| Severity | Medium (advisory) |
+| Applicability | Substantial instruction-bearing configuration |
+
+**Detection:** Config never bounds output (no length cap, no "code only / no preamble", no format spec). Complements TE004 (which flags *forced* verbosity; OS001 flags *absent* bounds).
+
+**Remediation:** Add a concise output contract, e.g. "Default to code only with no preamble; explain only when asked."
+
+#### OS002 — Full-File Rewrite Mandate
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | output-shaping (experimental) |
+| Severity | High (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Instructions require emitting entire files instead of diffs/patches ("return the complete file").
+
+**Remediation:** Prefer diffs/patches or targeted edits; reserve full-file output for newly created files.
+
+#### OS003 — Unconditional Verbose Reasoning
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | output-shaping (experimental) |
+| Severity | Medium (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Forces detailed chain-of-thought/explanation on every response regardless of task.
+
+**Remediation:** Make reasoning depth conditional on task complexity rather than global.
+
+#### OS004 — Output Echo / Restatement
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | output-shaping (experimental) |
+| Severity | Low (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Instructs the agent to restate the prompt, echo inputs, or repeat context back.
+
+**Remediation:** Remove echo/restatement requirements; have the agent act directly.
+
+#### OS005 — Verbose Format Mandate
+
+| Attribute | Value |
+|-----------|-------|
+| Dimension | output-shaping (experimental) |
+| Severity | Info (advisory) |
+| Applicability | Instruction-bearing configuration |
+
+**Detection:** Requires heavyweight formatting (decorative sections, full tables) on every response where compact output suffices.
+
+**Remediation:** Default to compact output; reserve rich formatting for when it is explicitly requested.
+
+---
+
 ## 10. Scoring Methodology
 
 ### 10.1 Dimensions and Weights
@@ -1071,6 +1270,11 @@ Custom subagents and slash commands are distinct configuration surfaces: a subag
 | Completeness | 0.15 | Gaps cause agent confusion and retry waste |
 | Conflict-Reachability | 0.10 | Contradictions cause unpredictable behavior |
 | Harness Quality | 0.10 | Setup/environment quality affects agent effectiveness |
+
+The six dimensions above sum to 1.0 and are the only inputs to `score.overall`.
+The experimental dimensions **Cache-Shaping** and **Output-Shaping** (§9.9, §9.10)
+carry **weight 0**: they are never folded into the overall score or grade and are
+reported only in a separate, opt-in experimental channel.
 
 ### 10.2 Score Calculation
 
@@ -1127,6 +1331,7 @@ To produce reproducible results, CATES measurements MUST be performed under thes
 4. **Traversal boundary:** The repository root. Symlinks pointing outside this boundary MUST be excluded.
 5. **File limits:** Maximum 50 configuration files, maximum 100KB per file, maximum depth 5 directories.
 6. **Binary exclusion:** Files with >10% non-printable characters or containing null bytes MUST be excluded.
+7. **Static scope:** Measurement is static analysis of configuration at rest — no execution, no LLM calls, no runtime telemetry. Experimental cache/output-shaping rules (§9.9, §9.10) therefore detect *predictive config smells*, not actual cache-hit % or output:input ratios; the latter are runtime signals deferred to a future Informative annex on Token-Economics Telemetry.
 
 ### 11.2 Invocation Assumptions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ Releases are automated via
 > from this analyzer package. Changes to the standard document do not
 > automatically produce a new analyzer release.
 
+## Unreleased
+
+### Features
+
+* **experimental:** add opt-in, non-normative cache-shaping (`CS001`–`CS005`) and
+  output-shaping (`OS001`–`OS005`) dimensions behind `--experimental` /
+  `--experimental-only` / `CATES_EXPERIMENTAL=1` / `experimental: true` in
+  `.cates.yml`. These are **OFF by default, carry zero scoring weight, and are
+  excluded from conformance and CI gates** — `score.overall` and conformance are
+  byte-identical with the flag on or off. Findings live in a separate
+  `result.experimental` channel and are **SemVer-exempt**.
+* **optimizer:** `cates-optimize --experimental` surfaces the estimated
+  cache/output token impact as advisory opportunities (never auto-applied, so the
+  no-loss-of-function guarantee is preserved).
+
 ## 1.2.0 (2026-06-02)
 
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ docker run --rm -v "$PWD:/work" cates-analyzer:latest .
 Requires Node.js **>= 20** for the npm install paths. The Docker image
 ships its own runtime plus `git` and `gh`.
 
+The package installs two commands: **`cates-analyzer`** (reports inefficiencies)
+and **`cates-optimize`** (deliberately applies the lossless fixes — see
+[Optimizer](#-optimizer--apply-lossless-fixes-cates-optimize)).
+
 ### Use it
 
 ```bash
@@ -393,7 +397,93 @@ cates-analyzer . --format json > reports/$(git rev-parse --short HEAD).json
 For multi-repo views use `cates-analyzer portfolio <path>` or the demo
 manifest (`cates-analyzer demo --limit 25`).
 
+## ⚡ Optimizer — apply lossless fixes (`cates-optimize`)
 
+The analyzer **reports** what's inefficient. `cates-optimize` is a **separate,
+deliberately-run tool** that **acts on that report**: it rewrites your Copilot
+primitives (instructions, prompts, chat modes, agents, skills, rules files) to be
+as token-efficient as possible **while guaranteeing no loss of function**, then
+prints a report of what it achieved and the estimated efficiency gain.
+
+It is intentionally **not** wired into `cates-analyzer` — you run it on purpose.
+
+### The guarantee
+
+`cates-optimize` only applies **lossless** transforms — it never rewrites,
+reorders, or rescopes guidance. It strips only mechanically-redundant or no-op
+bytes:
+
+| Optimizer | Rule | What it removes |
+| --- | --- | --- |
+| `dedupe-lines` | TE007 | Later exact duplicates of an instruction line (first copy stays) |
+| `dedupe-blocks` | TE007 | Later byte-identical multi-line blocks within a file |
+| `remove-filler` | TE003 | Standalone lines that only restate model defaults (e.g. "You are a helpful assistant") |
+| `whitespace` | — | Trailing whitespace, blank-line runs (code fences untouched) |
+
+Before writing any file, the tool verifies the **meaningful-instruction set** and
+**every code block** are byte-for-byte preserved, then **re-scores with the same
+CATES engine** so the before/after numbers are exact. Anything that needs human
+judgement (restructuring always-loaded context, extracting big code examples,
+rewriting forced verbosity or negative-constraint lists, deduping across files,
+removing secrets) is **left untouched** and surfaced as "remaining opportunities".
+
+Want the strictest purely-mechanical run? Add `--skip remove-filler` to keep only
+whitespace + exact-duplicate removal.
+
+### Use it
+
+```bash
+cates-optimize .                          # optimize the current repo, write changes
+cates-optimize . --dry-run                # preview the gain, write nothing
+cates-optimize . --backup                 # keep a <file>.orig next to each change
+cates-optimize . --format json            # machine-readable achievement report
+
+# Reuse a report you already produced with the analyzer:
+cates-analyzer . --format json > report.json
+cates-optimize --report report.json
+
+cates-optimize --list-optimizers          # show available optimizers
+cates-optimize . --only dedupe-lines,whitespace
+```
+
+The report leads with the headline efficiency gain (token reduction on active and
+always-loaded config), a before/after table (tokens, CATES score, findings), the
+per-file changes, the no-loss-of-function guarantee log, and the remaining
+manual opportunities.
+
+## 🧪 Experimental: cache & output shaping
+
+Input is the *cheapest* token class. Two higher-leverage axes are detectable
+statically and shipped as **experimental, non-normative** rules — **cache-shaping**
+(`CS001`–`CS005`: volatile tokens in the always-loaded prefix, dynamic-before-static
+ordering, …) and **output-shaping** (`OS001`–`OS005`: missing output contract,
+full-file-rewrite mandates, unconditional verbose reasoning, …).
+
+These are **OFF by default, carry zero scoring weight, and are excluded from
+conformance and CI gates** — your score and grade are byte-identical whether the
+flag is on or off. Run them to *see the wider token impact*:
+
+```bash
+cates-analyzer . --experimental         # full report + a labeled experimental section
+cates-analyzer . --experimental-only    # just the cache/output-shaping findings
+CATES_EXPERIMENTAL=1 cates-analyzer .    # or via env var
+cates-optimize . --experimental          # advisory token impact (never auto-applied)
+```
+
+Or opt in via policy:
+
+```yaml
+# .cates.yml
+experimental: true
+rules:
+  OS002: off                  # disable a specific experimental rule
+  CS001: { severity: low }    # or soften one
+```
+
+Findings live in a separate `result.experimental` channel with
+`"stability": "experimental"` and are **SemVer-exempt**. See
+[`docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md`](docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md)
+and `CATES-v1.0.md` §5.4 / §9.9 / §9.10. This is **not part of the standard yet**.
 
 ## 📊 What It Scores
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -103,3 +103,15 @@ will now fail unless `.cates.yml` lowers the severity.
 are released as document revisions, not as npm releases. When the standard
 graduates from `-draft` or moves to `1.1.0` / `2.0.0`, update the document
 header and reference the new version explicitly in analyzer release notes.
+
+## Experimental rules and dimensions
+
+Experimental rules and dimensions (currently cache-shaping `CS0xx` and
+output-shaping `OS0xx`, marked 🧪 in the catalog) are **exempt from SemVer**.
+They MAY change behavior, change severity, be renumbered, or be removed in any
+**minor** release without a breaking-change bump, because they are off by
+default, carry zero scoring weight, and never affect `score.overall`,
+conformance, or CI gates. Automation MUST NOT depend on experimental rule IDs or
+the `result.experimental` channel for gating. An experimental rule graduates to
+stable only by being assigned a non-zero weight and admitted to conformance —
+which changes default scores and therefore requires a **major** release.

--- a/docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md
+++ b/docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md
@@ -1,0 +1,297 @@
+# Proposal: Experimental Cache-Shaping & Output-Shaping Dimensions
+
+> 🧪 **Status: EXPERIMENTAL PROPOSAL — non-normative.**
+> Everything described here ships **off by default**, carries **zero scoring weight**,
+> is **excluded from conformance and CI gates**, and is **SemVer-exempt** (rules may
+> change or be removed in a minor release). Nothing here changes a repository's existing
+> CATES score or conformance level unless a user explicitly opts in.
+
+**Target version:** `cates-analyzer` 1.3.0 (minor) · **Owner:** TBD · **Created:** 2026-06-24
+
+---
+
+## 1. Summary
+
+CATES today optimizes one token class: **input** (the `token-efficiency` dimension shrinks
+always-loaded config). But under token-based billing, input is the *cheapest* class. Two
+higher-leverage classes are unaddressed:
+
+- **Cache** — a cache *hit* costs ≈ **0.1×** input (≈ 90% off). Whether a request hits is
+  driven by **prefix stability**, which is partly visible in static config.
+- **Output** — output tokens cost ≈ **2–5× input** and drive latency. Several config
+  anti-patterns provably inflate output.
+
+*(Illustrative ratios — Claude-family, 2026; verify per model/provider. The structural
+ordering `output ≫ uncached-input ≫ cached-input` is stable across vendors.)*
+
+This proposal adds two **experimental** scoring dimensions — `cache-shaping` and
+`output-shaping` — that flag the **statically-detectable** config smells which wreck cache
+hit-rate or inflate output, **without** touching the established score until the rules earn
+graduation.
+
+> The framing: CLEAR/CATES optimize *input authoring*. This adds two orthogonal axes —
+> **Cache** (structure) and **Output** (contract) — that can be improved without changing a
+> single instruction's meaning, so functionality is preserved by construction.
+
+---
+
+## 2. The "experimental for sure" guarantees (design contract)
+
+These are hard requirements for every change below. A reviewer should reject the PR if any
+is violated.
+
+| Guarantee | Mechanism |
+|---|---|
+| **Off by default** | Findings only produced when `--experimental` (CLI) or `experimental: true` (`.cates.yml`) is set. |
+| **Zero score impact** | New dimensions are **not** in `DIMENSION_WEIGHTS`; `score.overall` math is byte-for-byte unchanged. |
+| **Excluded from conformance** | Experimental findings never enter the `findings` array consumed by `evaluateConformance` / `level{1,2,3}Failures`. |
+| **Excluded from CI gates** | Not eligible for `failOn`, `minScore`, `requireLevel`, or `maxAlwaysLoadedTokens`. |
+| **Visibly labeled** | `🧪 EXPERIMENTAL (not scored)` banner in CLI; `"stability": "experimental"` in JSON; flagged in the rule catalog and docs. |
+| **Separate output channel** | Emitted under `result.experimental.*`, never merged into `result.findings`, so automation can't accidentally depend on it. |
+| **SemVer-exempt** | Documented in `VERSIONING.md`: experimental rule IDs may change/be removed in minor releases. |
+
+**Why isolation is non-negotiable:** `src/conformance.ts` fails Level 2 on *any* `high`
+finding and Level 3 on anything above `low`. If an experimental rule's finding leaked into
+`result.findings`, it would silently break existing users' conformance and CI gates. The
+separate channel is the safeguard.
+
+---
+
+## 3. Scope: static-detectable vs. runtime (be honest)
+
+CATES is **static, zero-LLM** analysis of config at rest (§11 Measurement). That bounds what
+these dimensions can do.
+
+### In scope (this proposal) — static config smells
+Config patterns that *predict* poor cache/output economics: volatile tokens in the cacheable
+prefix, dynamic-before-static ordering, full-file-rewrite mandates, unbounded output, forced
+verbose reasoning, etc. (rules in §4).
+
+### Out of scope (future, informative) — runtime telemetry
+Actual **cache-hit %**, **output:input ratio**, **reasoning-token share**, sticky-routing,
+and stream-and-cancel are **runtime** signals. They require a telemetry feed (gateway or
+billing export), not source files. Proposed as a **future Informative Annex G —
+Token-Economics Telemetry** and a possible `cates-rt` ingest mode. **Explicitly not in 1.3.0.**
+Calling this out prevents the failure mode of asserting runtime numbers the static analyzer
+cannot measure.
+
+---
+
+## 4. New dimensions & rules
+
+Two dimensions, dimension-prefixed IDs consistent with the existing catalog (`TE`, `SEC`, …):
+`CS` = cache-shaping, `OS` = output-shaping. Severities are **advisory only** while
+experimental (they aid prioritization but never gate or score).
+
+### 4.1 Cache-Shaping (`CS0xx`) — protect the cacheable prefix
+
+| ID | Title | Sev | Static detection (config at rest) |
+|----|-------|-----|-----------------------------------|
+| **CS001** | Volatile Tokens in Always-Loaded Config | high | Always-loaded scope embeds timestamps/dates, UUIDs, build numbers, git SHAs, or `current date/time` directives → busts the prefix every call. |
+| **CS002** | Dynamic-Before-Static Ordering | medium | Prompt/instruction template places variable placeholders (`${…}`, `{{…}}`) or `@include`s **ahead** of a large static block, minimizing the cacheable prefix. |
+| **CS003** | Non-Deterministic Context Directive | medium | Instructions tell the agent to inject live/volatile state at the top (e.g., "always include current git status / latest logs / today's date"). |
+| **CS004** | Unstable Tool/Context Ordering | low | Directives that randomize or re-sort tool lists / retrieved context per call. |
+| **CS005** | Fragmented Preamble (no shared prelude) | info | High cross-file near-duplication of preamble that could be one shared, cacheable prelude (correlates with `TE006`). |
+
+### 4.2 Output-Shaping (`OS0xx`) — contain the priciest token class
+
+| ID | Title | Sev | Static detection (config at rest) |
+|----|-------|-----|-----------------------------------|
+| **OS001** | Missing Output Contract | medium | Config never bounds output (no length cap, no "code-only / no-preamble", no format spec). Complements `TE004` (which flags *forced* verbosity; OS001 flags *absent* bounds). |
+| **OS002** | Full-File Rewrite Mandate | high | Instructions require emitting entire files instead of diffs/patches ("return the complete file"). Large output waste; same end-state achievable via patch. |
+| **OS003** | Unconditional Verbose Reasoning | medium | Forces detailed chain-of-thought/explanation on every response regardless of task → reasoning/output inflation. |
+| **OS004** | Output Echo / Restatement | low | Instructs the agent to restate the prompt, echo inputs, or repeat context back. |
+| **OS005** | Verbose Format Mandate | info | Requires heavyweight formatting (decorative sections, full tables) where compact output suffices. |
+
+Overlaps with existing `TE004`/`CNF002` are intentional and noted; graduation (§9) may merge
+or promote rules.
+
+---
+
+## 5. Architecture & code changes (file-by-file)
+
+### 5.1 `src/types.ts`
+- Extend `Dimension` with `'cache-shaping' | 'output-shaping'` **for typing only** — these
+  do **not** get weights (see 5.4).
+- Add a stability marker and a dedicated channel:
+  ```ts
+  export type Stability = 'stable' | 'experimental';
+
+  export interface ExperimentalFinding extends Finding {
+    stability: 'experimental';
+  }
+
+  // on AnalysisResult:
+  experimental?: {
+    enabled: boolean;
+    findings: ExperimentalFinding[];
+    dimensions: DimensionScore[]; // informational only; weight = 0
+  };
+  ```
+- Keep `result.findings` **stable-only**. Experimental findings live solely under
+  `result.experimental.findings`.
+
+### 5.2 `src/analyzers/cache-shaping.ts`, `src/analyzers/output-shaping.ts` (new)
+- Mirror the shape of `src/analyzers/token-efficiency.ts`.
+- Pure, deterministic, regex/AST detectors over `DiscoveredFile`s; reuse
+  `src/utils/tokenizer.ts` and `src/utils/regex-guards.ts`.
+- Each returns `ExperimentalFinding[]`. **Only invoked when experimental mode is on.**
+- Register in `src/analyzers/index.ts` behind the gate (do not add to the default analyzer
+  sweep).
+
+### 5.3 `src/rules/catalog.ts`
+- Add `CS0xx`/`OS0xx` entries. Extend `RuleMetadata` with `stability?: Stability` (default
+  `'stable'`); mark all new rules `stability: 'experimental'`.
+- Set `catesSection` to `'9.9'` (cache) / `'9.10'` (output).
+- `cates-analyzer rules` / `explain` must show a 🧪 marker for experimental rules.
+
+### 5.4 `src/scoring/calculator.ts`
+- **Do not** add the new dimensions to `DIMENSION_WEIGHTS` (it must keep summing to 1.0).
+  `score.overall` is provably unchanged.
+- Add a side computation that scores experimental dimensions **for display only** (weight 0),
+  written to `result.experimental.dimensions`, never folded into `overall`.
+- Add a regression test asserting overall score is identical with/without experimental on a
+  fixture corpus (see §7).
+
+### 5.5 `src/conformance.ts`
+- No behavioral change required **because** experimental findings never reach
+  `result.findings`. Add a defensive filter + a unit test proving `level{1,2,3}Failures`
+  ignore `stability: 'experimental'` even if one leaked in.
+
+### 5.6 `src/rule-config.ts` + `.cates.yml`
+- Add a top-level `experimental: boolean` (default `false`) to the policy schema.
+- Preserve existing precedence (`rules[id] > dimensions[dim] > defaults`). A user can:
+  ```yaml
+  experimental: true            # opt in to all experimental rules
+  rules:
+    OS002: off                  # …but disable a specific one
+    CS001: { severity: low }    # …or soften it
+  ```
+- When `experimental: false`, the analyzers in 5.2 are not run at all (no wasted work).
+
+### 5.7 `src/cli/index.ts`
+- New flags: `--experimental` (run + show experimental findings), `--experimental-only`
+  (only the experimental section, useful for focused review), and surface in `--help`.
+- Render a distinct, clearly-labeled block:
+  ```
+  🧪 Experimental — NOT scored, subject to change
+     CS001  high    .github/copilot-instructions.md:3  Volatile "current date" in always-loaded config
+     OS002  high    .github/copilot-instructions.md:42 Mandates full-file output; prefer diffs
+  ```
+- JSON output: add an `experimental` object sibling to `findings`; never inside `findings`.
+  Each entry carries `"stability": "experimental"`.
+
+### 5.8 `src/scoring/report.ts` / `src/optimizer/report.ts`
+- Add the experimental section to text + JSON reports, gated and labeled. Default reports
+  (no flag) are byte-identical to today.
+
+---
+
+## 6. Standard changes (`CATES-v1.0.md`) — all Informative/Experimental
+
+Leverage the existing §4.5 *Normative vs. Informative* split — experimental content is
+**Informative** and MUST NOT affect conformance.
+
+- **§4.2 Rule Identifiers** — register `CS`/`OS` prefixes; define a 🧪 **Experimental**
+  status marker for rule IDs.
+- **§4.5** — add an "Experimental (non-normative)" status: experimental rules are Informative,
+  carry zero weight, and are excluded from conformance classes/profiles.
+- **§5 Conceptual Model** — extend 5.1/5.2 with the **token cost vector**
+  (cached-input ≈ 0.1×, uncached-input 1×, cache-write 1.25–2×, output ≈ 5×) and a
+  **prefix-stability** concept; note `1 output ≈ ~50 cached-input` as motivation.
+- **§9.9 Cache-Shaping Rules (Experimental)** and **§9.10 Output-Shaping Rules
+  (Experimental)** — full rule definitions using the §9.1 attribute table, each headed
+  "Experimental — Informative".
+- **§8 Conformance** — one sentence: experimental rules are excluded from all classes/profiles.
+- **§10 Scoring** — one sentence: experimental dimensions have weight 0 and are excluded from
+  the overall score and grade.
+- **§11 Measurement** — reaffirm static-only; reference future **Annex G (Telemetry)** for
+  runtime cache/output measurement.
+
+---
+
+## 7. Testing strategy
+
+- **Fixtures** under `fixtures/experimental/` — minimal repos exhibiting each `CS`/`OS`
+  anti-pattern plus clean counterparts (true-positive and true-negative per rule).
+- **Unit tests** (`tests/`) — one per rule (detection + remediation message + advisory
+  severity), following existing analyzer test patterns.
+- **Isolation guardrail tests (the important ones):**
+  1. `score.overall` and `grade` are **identical** with and without `--experimental` across
+     the full fixture corpus.
+  2. `evaluateConformance` / `evaluateGates` results are **identical** with experimental on.
+  3. `result.findings` never contains a `stability: 'experimental'` entry.
+  4. With `experimental: false`, the new analyzers are not invoked (spy/mocks).
+- **Snapshot test** of default (no-flag) CLI/JSON output to prove zero drift for existing users.
+
+---
+
+## 8. Versioning & release
+
+- **Minor bump → 1.3.0** (additive, opt-in). Existing behavior unchanged.
+- `CHANGELOG.md` entry clearly labeled **Experimental**.
+- `VERSIONING.md` — add a clause: *experimental rules/dimensions are exempt from SemVer; they
+  may change or be removed in any minor release.*
+- release-please config: no special handling needed beyond the conventional-commit
+  `feat:` (minor). Keep the experimental rules out of any "stable rule count" advertised in
+  the README.
+
+---
+
+## 9. Phased rollout
+
+- [ ] **Phase 0 — Spec groundwork.** §4.5/§5 edits + the experimental marker convention. No code.
+- [ ] **Phase 1 — Engine plumbing (zero rules).** Experimental channel in `types.ts`, the
+      `experimental` policy flag, CLI flags, report section, scoring isolation, guardrail
+      tests. Ship with **no active rules** to validate isolation in production first.
+- [ ] **Phase 2 — Cache-Shaping.** `cache-shaping.ts` + `CS001–CS005` + fixtures + tests + §9.9.
+- [ ] **Phase 3 — Output-Shaping.** `output-shaping.ts` + `OS001–OS005` + fixtures + tests + §9.10.
+- [ ] **Phase 4 — Docs & DX.** `docs/RULE-CATALOG.md` experimental section, this guide linked
+      from README (with a 🧪 note), `examples/`, `explain`/`rules` 🧪 markers.
+- [ ] **Phase 5 — Future (separate proposal).** Annex G telemetry + `cates-rt` ingest.
+
+---
+
+## 10. Graduation criteria (experimental → stable)
+
+A rule graduates only when:
+1. **Precision/recall** measured on a labeled corpus (target: precision ≥ 0.9, low FP rate).
+2. Sustained low false-positive feedback across real repos.
+3. Remediation is concrete and autofix-able where claimed.
+
+Promotion then: assign a **non-zero weight** (rebalancing existing weights) and admit to
+conformance — which **changes default scores**, so it requires a **major** release and a
+migration note. Until then, weight stays 0.
+
+---
+
+## 11. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Experimental finding leaks into score/gates | Separate channel + 4 guardrail tests (§7); defensive filter in `conformance.ts`. |
+| False positives erode trust | Advisory-only severity, off by default, `explain` rationale, easy per-rule disable. |
+| Users build automation on unstable IDs | `"stability":"experimental"` in JSON + SemVer-exempt clause + separate channel. |
+| Overlap/confusion with `TE`/`CNF` rules | Document overlaps in §9.9/§9.10; plan merges at graduation. |
+| Scope creep into runtime claims | Hard line in §3; telemetry deferred to Annex G. |
+
+---
+
+## 12. Open questions
+
+- [ ] Confirm GitHub Copilot / AI-credits per-model treatment of cached input & output before
+      quoting ratios in any customer-facing surface (don't cite Anthropic/OpenAI numbers as
+      GitHub's). TBB hub: aka.ms/ghcpubb.
+- [ ] One combined `token-economics-experimental` dimension vs. two (`cache-shaping`,
+      `output-shaping`)? Two is clearer for graduation; one is simpler in the report.
+- [ ] Should `--experimental` also be enabled by an env var for CI experimentation
+      (`CATES_EXPERIMENTAL=1`)?
+- [ ] Minimum file-size thresholds for `OS001`/`CS002` to suppress noise on tiny configs.
+
+---
+
+### References
+- Source ideation: *"Scaling Prompt Optimization — Beyond Input Tokens (Cache & Output
+  Shaping)"* (three-axis model: Input / Cache / Output).
+- Pricing ratios are illustrative (Claude-family, 2026) and vary by provider/model — verify
+  against the current model card before use in customer-facing material.

--- a/docs/RULE-CATALOG.md
+++ b/docs/RULE-CATALOG.md
@@ -14,3 +14,23 @@ cates-analyzer explain TE004
 
 The catalog includes ID, title, dimension, severity, summary, detection, remediation, CATES section, and autofix support.
 
+## 🧪 Experimental rules (non-normative)
+
+The catalog also includes **experimental** cache-shaping (`CS001`–`CS005`) and
+output-shaping (`OS001`–`OS005`) rules, marked with a 🧪 in
+`cates-analyzer rules` and tagged `"stability": "experimental"` in the JSON.
+
+They are **off by default, carry zero scoring weight, and are excluded from
+conformance and CI gates**. Enable them explicitly:
+
+```bash
+cates-analyzer . --experimental        # full report + experimental section
+cates-analyzer . --experimental-only   # just the cache/output-shaping section
+CATES_EXPERIMENTAL=1 cates-analyzer .   # or via env var (handy for CI trials)
+cates-optimize . --experimental         # advisory token impact (never auto-applied)
+```
+
+See [`EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md`](./EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md)
+for the full proposal and `CATES-v1.0.md` §5.4 / §9.9 / §9.10 for the rule
+definitions. Experimental rule IDs are SemVer-exempt and may change.
+

--- a/fixtures/experimental/.github/copilot-instructions.md
+++ b/fixtures/experimental/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# Example Agent (CATES experimental fixture)
+
+<!-- TEST FIXTURE: deliberately exhibits cache/output-shaping smells for
+     CS001-CS005 / OS001-OS005. Not real guidance. -->
+
+Today's date and the current build #4821 are part of your standing context.
+Always include the current git status at the top of every conversation.
+
+## Project
+
+This is a TypeScript service. Use Drizzle ORM and Zod validation throughout
+the `src/` directory, with tests under `tests/` using Vitest.
+
+## Behavior
+
+- Always explain your reasoning step by step on every response.
+- When editing code, return the complete file contents in your reply.
+- Restate the prompt back to confirm understanding before answering.
+- Always present a comprehensive summary table for each response.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Analyze coding agent configurations for token efficiency, security, and CATES conformance",
   "type": "module",
   "bin": {
-    "cates-analyzer": "./dist/cli/index.js"
+    "cates-analyzer": "./dist/cli/index.js",
+    "cates-optimize": "./dist/optimizer/cli.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -24,7 +25,7 @@
     "CATES-v1.0.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/cli/index.js",
+    "build": "tsc && chmod +x dist/cli/index.js dist/optimizer/cli.js",
     "build:service": "tsc -p tsconfig.service.json && node -e \"require('fs').cpSync('service/web','dist-service/service/web',{recursive:true})\"",
     "dev": "tsx watch src/cli/index.ts",
     "start": "node dist/cli/index.js",

--- a/src/analyzers/cache-shaping.ts
+++ b/src/analyzers/cache-shaping.ts
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type { ConfigScope, ExperimentalFinding } from '../types.js';
+import { countTokens } from '../utils/tokenizer.js';
+
+/**
+ * EXPERIMENTAL — Cache-Shaping detectors (CS0xx). Non-normative, zero scoring
+ * weight. See docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md.
+ *
+ * Static config smells that predict poor prompt-cache economics: volatile tokens
+ * in the cacheable prefix, dynamic-before-static ordering, live-state directives,
+ * unstable ordering, and fragmented preambles. All detection is deterministic
+ * and operates on config at rest — no runtime cache-hit measurement.
+ */
+
+export interface CacheFile {
+  relativePath: string;
+  content: string;
+  scope: ConfigScope;
+}
+
+const VOLATILE_PATTERNS: Array<{ re: RegExp; label: string }> = [
+  { re: /\b(current|today'?s)\s+(date|time|datetime|timestamp)\b/i, label: 'current date/time directive' },
+  { re: /\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?/, label: 'embedded ISO timestamp' },
+  { re: /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i, label: 'embedded UUID' },
+  { re: /\bcommit\s+[0-9a-f]{7,40}\b/i, label: 'embedded git commit SHA' },
+  { re: /\b[0-9a-f]{40}\b/, label: 'embedded git SHA' },
+  { re: /\bbuild\s*#?\s*\d{2,}/i, label: 'embedded build number' },
+];
+
+const LIVE_STATE_RE = /\b(always |please )?(include|inject|embed|prepend|add)\b[^.\n]*\b(current git status|latest logs?|recent commits?|current time|today'?s date|live (state|data|output)|uptime|now\(\))/i;
+const UNSTABLE_ORDER_RE = /\b(randomi[sz]e|shuffle|re-?sort|reorder|rotate)\b[^.\n]*\b(tools?|context|retrieved|results?|order)/i;
+const PLACEHOLDER_RE = /(\$\{[^}]+\}|\{\{[^}]+\}\}|@(?:import|include)\b|@[\w./-]+\.(?:md|markdown|txt))/;
+
+function fenceMask(lines: string[]): boolean[] {
+  const mask = new Array<boolean>(lines.length).fill(false);
+  let inCode = false;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i]!.trimStart();
+    if (t.startsWith('```') || t.startsWith('~~~')) {
+      mask[i] = true;
+      inCode = !inCode;
+      continue;
+    }
+    mask[i] = inCode;
+  }
+  return mask;
+}
+
+export function detectCacheShaping(files: CacheFile[]): ExperimentalFinding[] {
+  const findings: ExperimentalFinding[] = [];
+
+  for (const file of files) {
+    const lines = file.content.split('\n');
+    const mask = fenceMask(lines);
+
+    // CS001 — only the always-loaded prefix is the high-value cache target.
+    if (file.scope === 'always-loaded') {
+      for (let i = 0; i < lines.length; i++) {
+        if (mask[i]) continue;
+        const hit = VOLATILE_PATTERNS.find(p => p.re.test(lines[i]!));
+        if (hit) {
+          findings.push(mk('CS001', 'high', 'high', file.relativePath, i + 1,
+            `Volatile token in always-loaded config (${hit.label}) busts the cacheable prefix on every call.`,
+            'Move volatile values out of the always-loaded prefix; supply them via tool inputs at the end of context.',
+            lines[i]!.trim().slice(0, 80), countTokens(file.content), 'cached-input'));
+          break; // one per file is enough signal
+        }
+      }
+    }
+
+    // CS003 — live/volatile state pulled into the preamble.
+    for (let i = 0; i < lines.length; i++) {
+      if (mask[i]) continue;
+      if (LIVE_STATE_RE.test(lines[i]!)) {
+        findings.push(mk('CS003', 'medium', 'medium', file.relativePath, i + 1,
+          'Non-deterministic context directive injects live/volatile state into the preamble, reducing cache reuse.',
+          'Fetch volatile state on-demand via tools instead of embedding it in always-loaded instructions.',
+          lines[i]!.trim().slice(0, 80), countTokens(file.content), 'cached-input'));
+        break;
+      }
+    }
+
+    // CS004 — directives that re-order tools/context per call.
+    for (let i = 0; i < lines.length; i++) {
+      if (mask[i]) continue;
+      if (UNSTABLE_ORDER_RE.test(lines[i]!)) {
+        findings.push(mk('CS004', 'low', 'medium', file.relativePath, i + 1,
+          'Unstable tool/context ordering directive changes the prefix between calls, defeating the cache.',
+          'Keep tool and context ordering stable and deterministic across calls.',
+          lines[i]!.trim().slice(0, 80), 0, 'cached-input'));
+        break;
+      }
+    }
+
+    // CS002 — variable placeholder ahead of a large static block.
+    const cs002 = detectDynamicBeforeStatic(file, lines, mask);
+    if (cs002) findings.push(cs002);
+  }
+
+  // CS005 — fragmented preamble shared across files (cross-file).
+  const cs005 = detectFragmentedPreamble(files);
+  if (cs005) findings.push(cs005);
+
+  return findings;
+}
+
+function detectDynamicBeforeStatic(file: CacheFile, lines: string[], mask: boolean[]): ExperimentalFinding | undefined {
+  let placeholderLine = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (mask[i]) continue;
+    if (PLACEHOLDER_RE.test(lines[i]!)) {
+      placeholderLine = i;
+      break;
+    }
+  }
+  if (placeholderLine < 0) return undefined;
+
+  const staticAfter = lines.slice(placeholderLine + 1).join('\n');
+  const staticTokens = countTokens(staticAfter);
+  // Only flag when a substantial static block sits AFTER the first placeholder
+  // and the placeholder is near the top — that static block can't be cached.
+  if (staticTokens < 200 || placeholderLine > lines.length * 0.5) return undefined;
+
+  return mk('CS002', 'medium', 'medium', file.relativePath, placeholderLine + 1,
+    `Dynamic-before-static ordering: a variable placeholder precedes ~${staticTokens} tokens of static content, shrinking the cacheable prefix.`,
+    'Put stable, static content first; move variable/dynamic content to the end.',
+    lines[placeholderLine]!.trim().slice(0, 80), staticTokens, 'cached-input');
+}
+
+function detectFragmentedPreamble(files: CacheFile[]): ExperimentalFinding | undefined {
+  const preambles = new Map<string, string[]>(); // normalized preamble -> files
+  for (const file of files) {
+    const preamble = file.content
+      .split('\n')
+      .filter(l => l.trim() !== '' && !l.trim().startsWith('#'))
+      .slice(0, 3)
+      .join(' ')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (preamble.length < 40) continue;
+    const list = preambles.get(preamble) ?? [];
+    list.push(file.relativePath);
+    preambles.set(preamble, list);
+  }
+  for (const [, sharing] of preambles) {
+    if (sharing.length >= 2) {
+      return mk('CS005', 'info', 'medium', sharing[0]!, undefined,
+        `Fragmented preamble: ${sharing.length} files repeat a near-identical preamble that could be one shared, cacheable prelude (also see TE006).`,
+        'Hoist the shared preamble into a single, stable, precedence-appropriate prelude.',
+        sharing.join(', ').slice(0, 80), 0, 'cached-input');
+    }
+  }
+  return undefined;
+}
+
+function mk(
+  ruleId: string,
+  severity: ExperimentalFinding['severity'],
+  confidence: ExperimentalFinding['confidence'],
+  file: string,
+  line: number | undefined,
+  message: string,
+  suggestion: string,
+  evidence: string,
+  tokenImpact: number,
+  tokenClass: 'cached-input' | 'output',
+): ExperimentalFinding {
+  return {
+    ruleId,
+    dimension: 'cache-shaping',
+    stability: 'experimental',
+    severity,
+    confidence,
+    message,
+    file,
+    ...(line !== undefined ? { line } : {}),
+    ...(evidence ? { evidence } : {}),
+    suggestion,
+    tokenImpact,
+    tokenClass,
+  };
+}

--- a/src/analyzers/experimental.ts
+++ b/src/analyzers/experimental.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type {
+  AnalyzerOptions,
+  ConfigScope,
+  ConfigType,
+  ExperimentalDimension,
+  ExperimentalDimensionScore,
+  ExperimentalFinding,
+  ExperimentalReport,
+} from '../types.js';
+import { detectCacheShaping } from './cache-shaping.js';
+import { detectOutputShaping } from './output-shaping.js';
+
+/**
+ * EXPERIMENTAL aggregator. Runs the cache/output-shaping detectors, applies
+ * rule-level policy overrides, and produces the isolated `experimental` channel.
+ *
+ * CRITICAL ISOLATION: nothing here ever touches `result.findings`,
+ * `result.score`, or conformance. The dimension scores below are display-only
+ * (weight 0) and are NEVER folded into `score.overall`.
+ */
+
+export interface ExperimentalInput {
+  relativePath: string;
+  content: string;
+  scope: ConfigScope;
+  type: ConfigType;
+}
+
+const SEVERITY_DEDUCTIONS: Record<string, number> = {
+  critical: 25,
+  high: 15,
+  medium: 8,
+  low: 3,
+  info: 0,
+};
+
+const EXPERIMENTAL_NOTE =
+  '🧪 EXPERIMENTAL (non-normative): cache/output-shaping is OFF by default, carries ZERO scoring weight, ' +
+  'and is excluded from conformance and CI gates. Token-impact figures are advisory static estimates ' +
+  '(cached-input ≈ 0.1× input; output ≈ 2–5× input — verify per model/provider). Rule IDs are SemVer-exempt.';
+
+export function analyzeExperimental(files: ExperimentalInput[], options: AnalyzerOptions): ExperimentalReport {
+  const raw: ExperimentalFinding[] = [
+    ...detectCacheShaping(files.map(f => ({ relativePath: f.relativePath, content: f.content, scope: f.scope }))),
+    ...detectOutputShaping(files.map(f => ({ relativePath: f.relativePath, content: f.content, type: f.type }))),
+  ];
+
+  const findings = applyRuleOverrides(raw, options.rules);
+
+  const dimensions: ExperimentalDimensionScore[] = (['cache-shaping', 'output-shaping'] as ExperimentalDimension[])
+    .map(dimension => buildDimensionScore(dimension, findings));
+
+  const estimatedTokenImpact = findings.reduce((sum, f) => sum + (f.tokenImpact ?? 0), 0);
+
+  return {
+    enabled: true,
+    findings,
+    dimensions,
+    estimatedTokenImpact,
+    note: EXPERIMENTAL_NOTE,
+  };
+}
+
+/** Rule-level overrides only (e.g. `rules: { OS002: off, CS001: { severity: low } }`). */
+function applyRuleOverrides(
+  findings: ExperimentalFinding[],
+  rules: AnalyzerOptions['rules'],
+): ExperimentalFinding[] {
+  const out: ExperimentalFinding[] = [];
+  for (const finding of findings) {
+    const override = rules[finding.ruleId] ?? rules[finding.ruleId.toUpperCase()];
+    if (override?.enabled === false) continue;
+    out.push(override?.severity ? { ...finding, severity: override.severity } : finding);
+  }
+  return out;
+}
+
+function buildDimensionScore(
+  dimension: ExperimentalDimension,
+  findings: ExperimentalFinding[],
+): ExperimentalDimensionScore {
+  const dimFindings = findings.filter(f => f.dimension === dimension);
+  let score = 100;
+  for (const f of dimFindings) score -= SEVERITY_DEDUCTIONS[f.severity] ?? 0;
+  score = Math.max(0, Math.min(100, score));
+  const estimatedTokenImpact = dimFindings.reduce((sum, f) => sum + (f.tokenImpact ?? 0), 0);
+  const label = dimension === 'cache-shaping' ? 'Cache-shaping' : 'Output-shaping';
+  return {
+    dimension,
+    score,
+    findings: dimFindings,
+    estimatedTokenImpact,
+    summary: `${label} (experimental, not scored): ${dimFindings.length} finding${dimFindings.length === 1 ? '' : 's'}, ~${estimatedTokenImpact.toLocaleString()} est. tokens`,
+  };
+}

--- a/src/analyzers/index.ts
+++ b/src/analyzers/index.ts
@@ -12,6 +12,7 @@ import { analyzeConflicts } from './conflicts.js';
 import { analyzePrompts, analyzeMcp, analyzeSetupSteps, analyzeHooks, analyzeEditorConfig } from './components.js';
 import { analyzeAgents } from './agents.js';
 import { analyzeCommands } from './commands.js';
+import { analyzeExperimental, type ExperimentalInput } from './experimental.js';
 import { calculateScore } from '../scoring/calculator.js';
 import { generateRecommendations } from '../scoring/recommendations.js';
 import { calculateSavings } from '../scoring/savings.js';
@@ -116,6 +117,21 @@ async function analyzeWithContext(options: AnalyzerOptions): Promise<AnalysisRes
   const recommendations = generateRecommendations(suppressionResult.findings, discovery);
   const savings = calculateSavings(score, discovery, recommendations);
 
+  // Phase 5 (opt-in): Experimental cache/output-shaping. Strictly isolated —
+  // produced only when enabled, written to a separate channel, zero score impact.
+  let experimental: AnalysisResult['experimental'];
+  if (options.experimental) {
+    const experimentalInput: ExperimentalInput[] = discovery.files
+      .filter(f => f.isActive)
+      .map(f => ({
+        relativePath: f.relativePath,
+        content: contents.get(f.path) ?? '',
+        scope: f.scope,
+        type: f.type,
+      }));
+    experimental = analyzeExperimental(experimentalInput, options);
+  }
+
   return {
     repoPath: options.repoPath,
     timestamp: new Date().toISOString(),
@@ -129,5 +145,6 @@ async function analyzeWithContext(options: AnalyzerOptions): Promise<AnalysisRes
     disabledFindings: ruleConfigResult.disabledFindings,
     disabledRuleIds: ruleConfigResult.disabledRuleIds,
     disabledDimensions: ruleConfigResult.disabledDimensions,
+    ...(experimental ? { experimental } : {}),
   };
 }

--- a/src/analyzers/output-shaping.ts
+++ b/src/analyzers/output-shaping.ts
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type { ConfigType, ExperimentalFinding } from '../types.js';
+import { countTokens } from '../utils/tokenizer.js';
+
+/**
+ * EXPERIMENTAL — Output-Shaping detectors (OS0xx). Non-normative, zero scoring
+ * weight. See docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md.
+ *
+ * Output is the priciest token class (≈ 2–5× input). These static detectors flag
+ * config that provably inflates output: no output contract, full-file-rewrite
+ * mandates, unconditional verbose reasoning, echo/restatement, verbose formats.
+ * Per-response token estimates are advisory only.
+ */
+
+export interface OutputFile {
+  relativePath: string;
+  content: string;
+  type: ConfigType;
+}
+
+const INSTRUCTION_TYPES = new Set<ConfigType>([
+  'root-instructions',
+  'agents-md',
+  'path-instructions',
+  'chat-mode',
+  'agent-definition',
+  'rules-config',
+]);
+
+// Any of these counts as the config bounding its output.
+const OUTPUT_CONTRACT_RE = /\b(be concise|keep it (short|brief|concise)|code only|no preamble|no prose|without (explanation|preamble)|max(imum)?\s+\d+\s+(words?|lines?|tokens?|characters?)|output format|respond with only|return only|terse|one[- ]line)\b/i;
+
+const FULL_FILE_RE = /\b(return|output|provide|give|emit|print|write out|reply with|respond with)\b[^.\n]*\b(the\s+)?(complete|entire|whole|full)\s+(file|contents?|source)\b/i;
+const VERBOSE_REASON_RE = /\b(always|on every (response|answer|reply)|for (every|each) (response|answer))\b[^.\n]*\b(explain|reasoning|step[- ]by[- ]step|chain[- ]of[- ]thought|think (through|out loud))/i;
+const VERBOSE_REASON_ALT_RE = /\b(explain your (full |complete )?reasoning|think step[- ]by[- ]step|show your (work|reasoning)|walk (me )?through your thinking)\b[^.\n]*\b(every|always|each time)?/i;
+const ECHO_RE = /\b(restate|echo|repeat back|repeat the|reiterate|quote back|summari[sz]e the (prompt|request|question))\b[^.\n]*\b(prompt|question|input|request|task|instructions?|context)?/i;
+const VERBOSE_FORMAT_RE = /\b(always )?(use|include|provide|format (as|with))\b[^.\n]*\b(detailed table|full table|comprehensive (summary|report|breakdown)|decorative|section headers for (every|each)|elaborate formatting)\b/i;
+
+function fenceMask(lines: string[]): boolean[] {
+  const mask = new Array<boolean>(lines.length).fill(false);
+  let inCode = false;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i]!.trimStart();
+    if (t.startsWith('```') || t.startsWith('~~~')) {
+      mask[i] = true;
+      inCode = !inCode;
+      continue;
+    }
+    mask[i] = inCode;
+  }
+  return mask;
+}
+
+export function detectOutputShaping(files: OutputFile[]): ExperimentalFinding[] {
+  const findings: ExperimentalFinding[] = [];
+
+  for (const file of files) {
+    const lines = file.content.split('\n');
+    const mask = fenceMask(lines);
+    const fileTokens = countTokens(file.content);
+
+    // OS001 — substantial instruction file that never bounds output at all.
+    if (INSTRUCTION_TYPES.has(file.type) && fileTokens >= 150 && !OUTPUT_CONTRACT_RE.test(file.content)) {
+      findings.push(mk('OS001', 'medium', 'medium', file.relativePath, undefined,
+        'Missing output contract: this instruction set never bounds output (no length cap, "code only/no preamble", or format spec), so responses default to verbose.',
+        'Add a concise output contract, e.g. "Default to code only with no preamble; explain only when asked."',
+        '', 300));
+    }
+
+    const firstMatch = (re: RegExp): number => {
+      for (let i = 0; i < lines.length; i++) {
+        if (mask[i]) continue;
+        if (re.test(lines[i]!)) return i;
+      }
+      return -1;
+    };
+
+    // OS002 — full-file rewrite mandate.
+    const os002 = firstMatch(FULL_FILE_RE);
+    if (os002 >= 0) {
+      findings.push(mk('OS002', 'high', 'medium', file.relativePath, os002 + 1,
+        'Full-file rewrite mandate forces emitting entire files instead of diffs/patches — large, avoidable output on every edit.',
+        'Prefer diffs/patches or targeted edits; reserve full-file output for newly created files.',
+        lines[os002]!.trim().slice(0, 80), 1000));
+    }
+
+    // OS003 — unconditional verbose reasoning.
+    const os003 = firstMatch(VERBOSE_REASON_RE);
+    const os003alt = os003 < 0 ? firstMatch(VERBOSE_REASON_ALT_RE) : -1;
+    const os003line = os003 >= 0 ? os003 : os003alt;
+    if (os003line >= 0) {
+      findings.push(mk('OS003', 'medium', 'medium', file.relativePath, os003line + 1,
+        'Unconditional verbose reasoning forces detailed explanation/CoT on every response regardless of task, inflating output.',
+        'Make reasoning depth conditional on task complexity rather than global.',
+        lines[os003line]!.trim().slice(0, 80), 400));
+    }
+
+    // OS004 — echo / restatement.
+    const os004 = firstMatch(ECHO_RE);
+    if (os004 >= 0) {
+      findings.push(mk('OS004', 'low', 'low', file.relativePath, os004 + 1,
+        'Output echo/restatement directive makes the agent repeat the prompt/context back, adding output tokens with no value.',
+        'Remove echo/restatement requirements; have the agent act directly.',
+        lines[os004]!.trim().slice(0, 80), 150));
+    }
+
+    // OS005 — verbose format mandate.
+    const os005 = firstMatch(VERBOSE_FORMAT_RE);
+    if (os005 >= 0) {
+      findings.push(mk('OS005', 'info', 'low', file.relativePath, os005 + 1,
+        'Verbose format mandate requires heavyweight formatting on every response where compact output would suffice.',
+        'Default to compact output; reserve rich formatting for when it is explicitly requested.',
+        lines[os005]!.trim().slice(0, 80), 100));
+    }
+  }
+
+  return findings;
+}
+
+function mk(
+  ruleId: string,
+  severity: ExperimentalFinding['severity'],
+  confidence: ExperimentalFinding['confidence'],
+  file: string,
+  line: number | undefined,
+  message: string,
+  suggestion: string,
+  evidence: string,
+  tokenImpact: number,
+): ExperimentalFinding {
+  return {
+    ruleId,
+    dimension: 'output-shaping',
+    stability: 'experimental',
+    severity,
+    confidence,
+    message,
+    file,
+    ...(line !== undefined ? { line } : {}),
+    ...(evidence ? { evidence } : {}),
+    suggestion,
+    tokenImpact,
+    tokenClass: 'output',
+  };
+}

--- a/src/analyzers/token-efficiency.ts
+++ b/src/analyzers/token-efficiency.ts
@@ -185,8 +185,10 @@ function checkVerboseExamples(fc: FileContent): Finding[] {
   return findings;
 }
 
-// Filler phrases the platform already handles
-const GENERIC_FILLER_PATTERNS = [
+// Filler phrases the platform already handles. Exported so the optimizer
+// (`cates-optimize`) removes exactly what this analyzer flags as TE003,
+// keeping detection and remediation in lockstep.
+export const GENERIC_FILLER_PATTERNS = [
   { pattern: /you are a helpful assistant/i, label: '"You are a helpful assistant"' },
   { pattern: /please be concise/i, label: '"Please be concise"' },
   { pattern: /respond in (markdown|plain text)/i, label: 'format instructions (platform default)' },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { resolveReviewSource } from '../sources.js';
 import type { DemoCategory } from '../demo-repos.js';
 import { scanDemo, type DemoScanResult } from '../demo.js';
 import { isTokenizerId, listTokenizers, type TokenizerId } from '../utils/tokenizer.js';
+import { formatExperimental } from '../scoring/report.js';
 import type { AnalysisResult, Severity } from '../types.js';
 
 program
@@ -85,6 +86,8 @@ program
   .option('--compare-tokenizers <list>', 'Comma-separated tokenizers to report side-by-side (e.g. openai-cl100k,anthropic-claude)')
   .option('--fix', 'Apply safe automatic fixes')
   .option('--fix-dry-run', 'Show safe automatic fixes without writing files')
+  .option('--experimental', 'Include experimental (non-normative) cache/output-shaping findings — not scored')
+  .option('--experimental-only', 'Show only the experimental cache/output-shaping section')
   .action(async (path: string, opts) => runAnalyze(path, opts));
 
 program
@@ -106,6 +109,8 @@ program
   .option('--compare-tokenizers <list>', 'Comma-separated tokenizers to report side-by-side')
   .option('--keep-worktree', 'Keep temporary clone after reviewing GitHub sources')
   .option('--no-gh', 'Use git directly instead of gh for GitHub sources')
+  .option('--experimental', 'Include experimental (non-normative) cache/output-shaping findings — not scored')
+  .option('--experimental-only', 'Show only the experimental cache/output-shaping section')
   .action(async (source: string, opts) => runReview(source, opts));
 
 program
@@ -148,7 +153,8 @@ program
       const format = formatOpt(opts.format, ['json', 'pretty']);
       if (format === 'pretty') {
         for (const rule of RULE_CATALOG) {
-          process.stdout.write(`${rule.id} ${rule.title} [${rule.severity}/${rule.dimension}]\n  ${rule.summary}\n`);
+          const tag = rule.stability === 'experimental' ? '🧪 ' : '';
+          process.stdout.write(`${tag}${rule.id} ${rule.title} [${rule.severity}/${rule.dimension}]\n  ${rule.summary}\n`);
         }
       } else {
         process.stdout.write(rulesAsJson() + '\n');
@@ -169,7 +175,10 @@ program
       console.error(`Unknown CATES rule: ${ruleId}`);
       process.exit(1);
     }
-    process.stdout.write(`${rule.id} — ${rule.title}\n\nDimension: ${rule.dimension}\nSeverity: ${rule.severity}\nCATES section: ${rule.catesSection}\n\n${rule.summary}\n\nDetection: ${rule.detection}\n\nRemediation: ${rule.remediation}\n`);
+    const stability = rule.stability === 'experimental'
+      ? '\n\n🧪 EXPERIMENTAL — non-normative, not scored, excluded from conformance/CI, SemVer-exempt.'
+      : '';
+    process.stdout.write(`${rule.id} — ${rule.title}\n\nDimension: ${rule.dimension}\nSeverity: ${rule.severity}\nCATES section: ${rule.catesSection}\n\n${rule.summary}\n\nDetection: ${rule.detection}\n\nRemediation: ${rule.remediation}${stability}\n`);
   });
 
 program
@@ -298,6 +307,18 @@ async function executeAnalyze(repoPath: string, opts: Record<string, unknown>, d
   }
 
   const reportResult = displayPath ? { ...result, repoPath: displayPath } : result;
+
+  // Focused experimental view: only the cache/output-shaping section.
+  if (opts.experimentalOnly) {
+    if (format === 'sarif') throw new Error('--experimental-only supports pretty or json output');
+    if (format === 'json') {
+      process.stdout.write(JSON.stringify(result.experimental ?? { enabled: false }, null, 2) + '\n');
+    } else {
+      process.stdout.write(formatExperimental(reportResult) + '\n');
+    }
+    return evaluateResultGates(result, policy, opts);
+  }
+
   const reportText = createReport(reportResult, format);
   process.stdout.write((opts.quiet ? stripPrettyBanner(reportText) : reportText) + '\n');
 
@@ -328,7 +349,20 @@ function buildAnalyzeOptions(
     suppressions: policy.suppressions ?? [],
     rules: policy.rules ?? {},
     dimensions: policy.dimensions ?? {},
+    experimental: experimentalEnabled(opts, policy),
   };
+}
+
+/**
+ * Experimental mode is enabled by any of: the --experimental / --experimental-only
+ * flags, `experimental: true` in policy, or the CATES_EXPERIMENTAL=1 env var
+ * (handy for CI experimentation). Default is off.
+ */
+function experimentalEnabled(opts: Record<string, unknown>, policy: CatesPolicy): boolean {
+  if (opts.experimental === true || opts.experimentalOnly === true) return true;
+  if (policy.experimental === true) return true;
+  const env = process.env.CATES_EXPERIMENTAL;
+  return env === '1' || env === 'true';
 }
 
 function evaluateResultGates(result: AnalysisResult, policy: CatesPolicy, opts: Record<string, unknown>): number {
@@ -537,6 +571,7 @@ function buildCompletionScript(shell: 'bash' | 'zsh'): string {
     '--no-evidence', '--min-score', '--require-level', '--fail-on', '--max-always-loaded',
     '--tokenizer', '--compare-tokenizers', '--fix', '--fix-dry-run', '--demo', '--repos-file',
     '--category', '--limit', '--concurrency', '--keep-worktree', '--no-gh', '--fail-fast',
+    '--experimental', '--experimental-only',
     '--help', '--version',
   ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,3 +22,11 @@ export { createReport } from './scoring/report.js';
 export { evaluateConformance, evaluateGates } from './conformance.js';
 export { RULE_CATALOG, getRule } from './rules/catalog.js';
 export type { AnalysisResult, Finding, Score, AnalyzerOptions } from './types.js';
+
+// Optimizer: a separate, deliberately-invoked tool that rewrites primitives for
+// token efficiency with a guaranteed no-loss-of-function property.
+export { optimize } from './optimizer/index.js';
+export { OPTIMIZERS, selectOptimizers, meaningfulSignature } from './optimizer/optimizers.js';
+export { renderOptimizationReport } from './optimizer/report.js';
+export type { OptimizationReportFormat } from './optimizer/report.js';
+export type { OptimizationResult, OptimizeOptions } from './optimizer/types.js';

--- a/src/optimizer/cli.ts
+++ b/src/optimizer/cli.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { program } from 'commander';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { optimize } from './index.js';
+import { OPTIMIZERS } from './optimizers.js';
+import { renderOptimizationReport, type OptimizationReportFormat } from './report.js';
+import { loadPolicy } from '../policy.js';
+import { isTokenizerId, listTokenizers, type TokenizerId } from '../utils/tokenizer.js';
+import type { AnalysisResult } from '../types.js';
+
+/** Thrown for user input mistakes (bad flag/value) so the CLI can exit with 2. */
+class UsageError extends Error {}
+
+/**
+ * `cates-optimize` — a SEPARATE, deliberately-invoked tool (not part of the
+ * `cates-analyzer` flow). It consumes a CATES analysis and rewrites the Copilot
+ * primitives to be as token-efficient as possible while guaranteeing no loss of
+ * function, then prints a report of what it achieved.
+ */
+
+program
+  .name('cates-optimize')
+  .description(
+    'Apply lossless token-efficiency optimizations to coding-agent primitives ' +
+    '(instructions, prompts, chat modes, agents, skills, rules) and report the gain. ' +
+    'Guarantees no loss of function. Separate from cates-analyzer — run it deliberately.',
+  )
+  .version('1.0.0')
+  .argument('[path]', 'Path to repository root', '.')
+  .option('-f, --format <format>', 'Report format: markdown or json', 'markdown')
+  .option('--report <file>', 'Reuse a prior `cates-analyzer --format json` report as the baseline')
+  .option('--dry-run', 'Show what would change without writing any files')
+  .option('--backup', 'Write a sibling <file>.orig backup before changing each file')
+  .option('--only <list>', 'Comma-separated optimizer ids to run (default: all)')
+  .option('--skip <list>', 'Comma-separated optimizer ids to skip')
+  .option('--experimental', 'Also surface experimental (non-normative) cache/output-shaping token impact (advisory; never auto-applied)')
+  .option('--tokenizer <name>', 'Canonical tokenizer: openai-cl100k, openai-o200k, anthropic-claude, approx')
+  .option('--policy <path>', 'Path to .cates.yml/.json policy file (for suppressions)')
+  .option('--max-files <n>', 'Maximum config files to analyze', '50')
+  .option('--max-depth <n>', 'Maximum directory traversal depth', '5')
+  .option('--list-optimizers', 'List available optimizers and exit')
+  .addHelpText('after', `
+Exit codes:
+  0  Optimization completed (or dry run / listing) successfully
+  1  Runtime error (unreadable repo, invalid report file)
+  2  Usage error (bad flag/optimizer id/tokenizer)
+
+Examples:
+  $ cates-optimize .                              # optimize current repo, write changes
+  $ cates-optimize . --dry-run                    # preview the gain, write nothing
+  $ cates-analyzer . --format json > r.json
+  $ cates-optimize --report r.json --backup       # reuse a report, keep .orig backups
+  $ cates-optimize . --only dedupe-lines,whitespace
+  $ cates-optimize . --experimental             # also show cache/output-shaping token impact
+  $ cates-optimize --list-optimizers
+`);
+
+program.exitOverride((err) => {
+  if (err.code === 'commander.helpDisplayed' || err.code === 'commander.version' || err.code === 'commander.help') {
+    process.exit(0);
+  }
+  process.exit(2);
+});
+
+program.action(async (path: string, opts: Record<string, unknown>) => {
+  try {
+    if (opts.listOptimizers) {
+      for (const o of OPTIMIZERS) {
+        process.stdout.write(`${o.id}  [${o.ruleIds.join(', ') || 'general'}] (${o.safety}${o.defaultOn ? ', default' : ''})\n    ${o.description}\n`);
+      }
+      process.exit(0);
+    }
+
+    const format = parseFormat(opts.format);
+    const tokenizer = parseTokenizer(opts.tokenizer);
+    const report = await loadReport(opts.report);
+    const repoPath = report && isDefaultPath(path) ? report.repoPath : resolve(path);
+    const policy = await loadPolicy(repoPath, strOpt(opts.policy));
+
+    const result = await optimize({
+      repoPath,
+      ...(report ? { report } : {}),
+      ...(tokenizer ? { tokenizer } : {}),
+      dryRun: Boolean(opts.dryRun),
+      backup: Boolean(opts.backup),
+      experimental: Boolean(opts.experimental) || policy.experimental === true || process.env.CATES_EXPERIMENTAL === '1' || process.env.CATES_EXPERIMENTAL === 'true',
+      ...(listOpt(opts.only) ? { only: listOpt(opts.only) } : {}),
+      ...(listOpt(opts.skip) ? { skip: listOpt(opts.skip) } : {}),
+      suppressions: policy.suppressions ?? [],
+      maxFiles: numOpt(opts.maxFiles, '--max-files') ?? 50,
+      maxDepth: numOpt(opts.maxDepth, '--max-depth') ?? 5,
+    });
+
+    process.stdout.write(renderOptimizationReport(result, format) + (format === 'json' ? '\n' : ''));
+    process.exit(0);
+  } catch (err) {
+    console.error('Error:', err instanceof Error ? err.message : err);
+    const usage = err instanceof UsageError || (err instanceof Error && /^Unknown optimizer/.test(err.message));
+    process.exit(usage ? 2 : 1);
+  }
+});
+
+program.parse();
+
+function isDefaultPath(path: string): boolean {
+  return path === '.' || path === undefined;
+}
+
+function parseFormat(value: unknown): OptimizationReportFormat {
+  const fmt = typeof value === 'string' ? value : 'markdown';
+  if (fmt === 'markdown' || fmt === 'json') return fmt;
+  throw new UsageError('--format must be one of: markdown, json.');
+}
+
+function parseTokenizer(value: unknown): TokenizerId | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value !== 'string' || !isTokenizerId(value)) {
+    throw new UsageError(`--tokenizer must be one of: ${listTokenizers().map(t => t.id).join(', ')}.`);
+  }
+  return value;
+}
+
+function listOpt(value: unknown): string[] | undefined {
+  if (typeof value !== 'string') return undefined;
+  const items = value.split(',').map(v => v.trim()).filter(v => v.length > 0);
+  return items.length > 0 ? items : undefined;
+}
+
+function strOpt(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numOpt(value: unknown, name: string): number | undefined {
+  if (typeof value !== 'string') return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new UsageError(`${name} must be a non-negative integer.`);
+  return parsed;
+}
+
+async function loadReport(value: unknown): Promise<AnalysisResult | undefined> {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  let raw: string;
+  try {
+    raw = await readFile(resolve(value), 'utf-8');
+  } catch {
+    throw new Error(`Could not read report file: ${value}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new UsageError(`Report file is not valid JSON: ${value}`);
+  }
+  if (Array.isArray(parsed)) {
+    throw new UsageError('Report file looks like an --individual array; pass a single-repo report instead.');
+  }
+  const candidate = parsed as Partial<AnalysisResult>;
+  if (!candidate || typeof candidate !== 'object' || !candidate.discovery || !candidate.score) {
+    throw new UsageError(`Report file is not a CATES analysis report: ${value}`);
+  }
+  return parsed as AnalysisResult;
+}

--- a/src/optimizer/index.ts
+++ b/src/optimizer/index.ts
@@ -1,0 +1,407 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { readFile, writeFile, access } from 'node:fs/promises';
+import { analyze } from '../analyzers/index.js';
+import { analyzeInMemory } from '../analyze-in-memory.js';
+import {
+  countTokens,
+  getDefaultTokenizer,
+  withTokenizer,
+  type TokenizerId,
+} from '../utils/tokenizer.js';
+import type { AnalysisResult, DiscoveredFile, Recommendation } from '../types.js';
+import { selectOptimizers, meaningfulSignature, isProseFile } from './optimizers.js';
+import type {
+  AppliedOptimizerInfo,
+  FileOptimization,
+  OptimizationResult,
+  OptimizeOptions,
+  OptimizerChangeRecord,
+  RemainingRecommendation,
+} from './types.js';
+
+/**
+ * Optimize the Copilot primitives in a repository for token efficiency while
+ * guaranteeing no loss of function.
+ *
+ * Pipeline:
+ *   1. Establish a baseline by running the CATES analyzer (or reusing a report).
+ *   2. Apply only lossless optimizers to each active primitive file.
+ *   3. Verify the meaningful-instruction signature is unchanged per file; revert
+ *      any file that would lose content (defence in depth — should never fire).
+ *   4. Re-score with the SAME analyzer engine (analyzeInMemory) for exact parity.
+ *   5. Write changes (unless dry-run) and return an achievement report.
+ */
+export async function optimize(opts: OptimizeOptions): Promise<OptimizationResult> {
+  const workingTokenizer: TokenizerId =
+    opts.tokenizer ?? (opts.report?.discovery.tokenizer as TokenizerId | undefined) ?? getDefaultTokenizer();
+  const suppressions = opts.suppressions ?? [];
+  const maxFiles = opts.maxFiles ?? 50;
+  const maxDepth = opts.maxDepth ?? 5;
+  const notes: string[] = [];
+
+  // 1. Baseline ("before"). Reuse the supplied report only when its tokenizer
+  //    matches (and it carries experimental data if we need it); otherwise
+  //    re-analyze so before/after numbers are comparable.
+  const wantExperimental = opts.experimental === true;
+  let before = opts.report;
+  if (before && before.discovery.tokenizer === workingTokenizer && (!wantExperimental || before.experimental)) {
+    notes.push('Reused the provided CATES report as the baseline.');
+  } else {
+    if (before) notes.push('Re-analyzed for a tokenizer-consistent baseline (report tokenizer differed).');
+    before = await analyze({ repoPath: opts.repoPath, tokenizer: workingTokenizer, suppressions, maxFiles, maxDepth, experimental: wantExperimental });
+  }
+
+  const activeFiles = before.discovery.files.filter(f => f.isActive);
+  const optimizers = selectOptimizers(opts.only, opts.skip);
+
+  if (activeFiles.length === 0) {
+    notes.push('No active coding-agent configuration files were found to optimize.');
+    return emptyResult(opts, before, workingTokenizer, optimizers, notes);
+  }
+
+  // 2 + 3. Apply optimizers per file with the in-context tokenizer so per-file
+  //         token counts match the analyzer's discovery counts exactly.
+  const optimizerStats = new Map<string, { files: Set<string>; tokens: number }>();
+  for (const o of optimizers) optimizerStats.set(o.id, { files: new Set(), tokens: 0 });
+
+  const fileResults: FileOptimization[] = [];
+  const editedByRelative = new Map<string, string>(); // relativePath -> optimized content
+  const originalByRelative = new Map<string, string>();
+  const backups: string[] = [];
+  let structuredSkipped = 0;
+
+  // Per-file token counts were already computed by the baseline analysis and
+  // discovered-file lookups are needed in the write loop; index them once so the
+  // hot path never does an O(files) scan or a redundant baseline re-tokenization.
+  const beforeTokenByRel = new Map(activeFiles.map(f => [f.relativePath, f.tokenCount] as const));
+  const discoveredByRel = new Map(activeFiles.map(f => [f.relativePath, f] as const));
+
+  await withTokenizer(workingTokenizer, async () => {
+    for (const file of activeFiles) {
+      let original: string;
+      try {
+        original = await readFile(file.path, 'utf-8');
+      } catch {
+        notes.push(`Skipped ${file.relativePath}: could not be read (it may have moved since analysis).`);
+        continue;
+      }
+      // Always keep the original so the file is included (unchanged) in the
+      // post-optimization re-score, even when it isn't a candidate for editing.
+      originalByRelative.set(file.relativePath, original);
+
+      // Only prose primitives are optimized; structured configs (JSON/YAML/shell)
+      // are never modified, to keep the no-loss-of-function guarantee airtight.
+      if (!isProseFile(file.relativePath)) {
+        structuredSkipped++;
+        continue;
+      }
+
+      let current = original;
+      const changes: OptimizerChangeRecord[] = [];
+      const localStats = new Map<string, number>(); // optimizerId -> tokens removed
+      // Seed from the baseline count (already in workingTokenizer); only the
+      // CHANGED output of each optimizer is re-tokenized, and that count is
+      // carried into the next step — so a file costs one BPE encode per
+      // optimizer that actually edits it, not 2N+2.
+      const tokensBefore = beforeTokenByRel.get(file.relativePath) ?? countTokens(original);
+      let currentTokens = tokensBefore;
+      for (const optimizer of optimizers) {
+        const stepBefore = current;
+        const { content: next, edits } = optimizer.apply(stepBefore);
+        if (edits.length === 0 || next === stepBefore) continue;
+        const nextTokens = countTokens(next);
+        const removed = Math.max(0, currentTokens - nextTokens);
+        current = next;
+        currentTokens = nextTokens;
+        for (const edit of edits) {
+          changes.push({
+            optimizerId: optimizer.id,
+            ruleIds: optimizer.ruleIds,
+            description: edit.description,
+            ...(edit.line !== undefined ? { line: edit.line } : {}),
+          });
+        }
+        localStats.set(optimizer.id, (localStats.get(optimizer.id) ?? 0) + removed);
+      }
+
+      if (current === original) continue;
+      const tokensAfter = currentTokens;
+      // Lossless but no token win (e.g. only a trailing-newline tweak) — leave the
+      // file alone rather than create pointless churn in the user's diff.
+      if (tokensBefore - tokensAfter <= 0) continue;
+
+      // Defence in depth: never write a file that would drop meaningful content.
+      const preserved = meaningfulSignature(original) === meaningfulSignature(current);
+      if (!preserved) {
+        notes.push(`Reverted ${file.relativePath}: optimization would have changed meaningful content.`);
+        fileResults.push(buildFileResult(file, original, original, tokensBefore, tokensBefore, [], false,
+          'meaningful-instruction signature changed'));
+        continue;
+      }
+
+      for (const [id, tokens] of localStats) {
+        const stat = optimizerStats.get(id)!;
+        stat.files.add(file.relativePath);
+        stat.tokens += tokens;
+      }
+      editedByRelative.set(file.relativePath, current);
+      fileResults.push(buildFileResult(file, original, current, tokensBefore, tokensAfter, changes, true));
+    }
+  });
+
+  if (structuredSkipped > 0) {
+    notes.push(`Left ${structuredSkipped} structured config file(s) (JSON/YAML/shell) untouched — only prose instruction primitives are optimized.`);
+  }
+
+  // 4. Re-score with the same analyzer engine for exact before/after parity.
+  //    Skip the whole re-analysis when nothing changed — the baseline already is
+  //    the "after" state, so an already-optimal repo costs zero extra work here.
+  let after = before;
+  if (editedByRelative.size > 0) {
+    const memFiles = activeFiles
+      .filter(f => originalByRelative.has(f.relativePath))
+      .map(f => ({
+        path: f.relativePath,
+        content: editedByRelative.get(f.relativePath) ?? originalByRelative.get(f.relativePath)!,
+      }));
+    after = await analyzeInMemory({ files: memFiles, tokenizer: workingTokenizer, suppressions, maxFiles, maxDepth, experimental: wantExperimental });
+  }
+
+  // 5. Write to disk unless this is a dry run.
+  const keptFiles = fileResults.filter(f => f.changed && f.functionPreserved);
+  if (!opts.dryRun) {
+    for (const fileResult of keptFiles) {
+      const discovered = discoveredByRel.get(fileResult.relativePath)!;
+      if (opts.backup) {
+        const backupPath = `${discovered.path}.orig`;
+        if (!(await exists(backupPath))) {
+          await writeFile(backupPath, originalByRelative.get(fileResult.relativePath)!, 'utf-8');
+          backups.push(`${fileResult.relativePath}.orig`);
+        }
+      }
+      await writeFile(discovered.path, editedByRelative.get(fileResult.relativePath)!, 'utf-8');
+    }
+  } else {
+    notes.push('Dry run: no files were written.');
+  }
+
+  return assembleResult({
+    opts, before, after, workingTokenizer, optimizers, optimizerStats,
+    fileResults, activeCount: activeFiles.length, backups, notes,
+  });
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildFileResult(
+  file: DiscoveredFile,
+  original: string,
+  optimized: string,
+  tokensBefore: number,
+  tokensAfter: number,
+  changes: OptimizerChangeRecord[],
+  preserved: boolean,
+  reverted?: string,
+): FileOptimization {
+  return {
+    relativePath: file.relativePath,
+    type: file.type,
+    scope: file.scope,
+    changed: optimized !== original,
+    tokensBefore,
+    tokensAfter,
+    tokensSaved: Math.max(0, tokensBefore - tokensAfter),
+    bytesBefore: Buffer.byteLength(original, 'utf-8'),
+    bytesAfter: Buffer.byteLength(optimized, 'utf-8'),
+    changes,
+    functionPreserved: preserved,
+    ...(reverted ? { reverted } : {}),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pct(part: number, whole: number): number {
+  if (whole <= 0) return 0;
+  return Math.round((part / whole) * 1000) / 10;
+}
+
+function tokenEfficiencyFindings(result: AnalysisResult): number {
+  return result.findings.filter(f => f.dimension === 'token-efficiency').length;
+}
+
+function remainingRecommendation(rec: Recommendation): RemainingRecommendation {
+  let reason: string;
+  if (rec.safety === 'manual') {
+    reason = 'Security/critical change — must be reviewed and applied by a human.';
+  } else if (rec.effort === 'moderate' || rec.effort === 'significant') {
+    reason = 'Requires restructuring or rewriting content, which falls outside the lossless guarantee.';
+  } else {
+    reason = 'Requires human judgement to preserve intent (e.g. rescoping or rephrasing).';
+  }
+  return {
+    title: rec.title,
+    ruleIds: rec.ruleIds,
+    files: rec.files,
+    tokenSavings: rec.tokenSavings,
+    effort: rec.effort,
+    safety: rec.safety,
+    reason,
+  };
+}
+
+interface AssembleArgs {
+  opts: OptimizeOptions;
+  before: AnalysisResult;
+  after: AnalysisResult;
+  workingTokenizer: TokenizerId;
+  optimizers: ReturnType<typeof selectOptimizers>;
+  optimizerStats: Map<string, { files: Set<string>; tokens: number }>;
+  fileResults: FileOptimization[];
+  activeCount: number;
+  backups: string[];
+  notes: string[];
+}
+
+function assembleResult(args: AssembleArgs): OptimizationResult {
+  const { before, after, workingTokenizer, optimizers, optimizerStats, fileResults, activeCount, backups, notes } = args;
+
+  const activeTokensBefore = before.discovery.totalTokens;
+  const activeTokensAfter = after.discovery.totalTokens;
+  const activeTokensSaved = Math.max(0, activeTokensBefore - activeTokensAfter);
+  const alwaysBefore = before.discovery.alwaysLoadedTokens;
+  const alwaysAfter = after.discovery.alwaysLoadedTokens;
+  const alwaysSaved = Math.max(0, alwaysBefore - alwaysAfter);
+  const changedFiles = fileResults.filter(f => f.changed && f.functionPreserved);
+
+  const optimizerInfos: AppliedOptimizerInfo[] = optimizers.map(o => {
+    const stat = optimizerStats.get(o.id)!;
+    return {
+      id: o.id,
+      title: o.title,
+      ruleIds: o.ruleIds,
+      safety: o.safety,
+      description: o.description,
+      filesTouched: stat.files.size,
+      tokensSaved: stat.tokens,
+    };
+  });
+
+  const reverted = fileResults.filter(f => !f.functionPreserved).length;
+
+  return {
+    repoPath: before.repoPath,
+    timestamp: new Date().toISOString(),
+    tokenizer: workingTokenizer,
+    dryRun: Boolean(args.opts.dryRun),
+    efficiencyGainPct: pct(activeTokensSaved, activeTokensBefore),
+    estimatedTokensSavedPerInvocation: alwaysSaved,
+    totals: {
+      activeTokensBefore,
+      activeTokensAfter,
+      activeTokensSaved,
+      activeReductionPct: pct(activeTokensSaved, activeTokensBefore),
+      alwaysLoadedTokensBefore: alwaysBefore,
+      alwaysLoadedTokensAfter: alwaysAfter,
+      alwaysLoadedTokensSaved: alwaysSaved,
+      alwaysLoadedReductionPct: pct(alwaysSaved, alwaysBefore),
+      filesScanned: activeCount,
+      filesChanged: changedFiles.length,
+    },
+    score: {
+      overallBefore: before.score.overall,
+      overallAfter: after.score.overall,
+      gradeBefore: before.score.grade,
+      gradeAfter: after.score.grade,
+      totalFindingsBefore: before.findings.length,
+      totalFindingsAfter: after.findings.length,
+      tokenEfficiencyFindingsBefore: tokenEfficiencyFindings(before),
+      tokenEfficiencyFindingsAfter: tokenEfficiencyFindings(after),
+    },
+    optimizers: optimizerInfos,
+    files: fileResults,
+    remainingRecommendations: after.recommendations.map(remainingRecommendation),
+    guarantee: {
+      noLossOfFunction: reverted === 0,
+      method:
+        'Only lossless transforms (blank-line/whitespace hygiene, exact duplicate removal, platform-default filler removal). ' +
+        'Each file is verified to keep an identical set of meaningful instructions and byte-identical code blocks, then re-scored with the same CATES engine.',
+      invariantsChecked: [
+        'meaningful-instruction-set equality (per file)',
+        'code-block byte identity (per file)',
+        'analyzer re-score parity (analyzeInMemory)',
+      ],
+    },
+    ...(after.experimental ?? before.experimental ? { experimental: after.experimental ?? before.experimental } : {}),
+    backups,
+    notes,
+  };
+}
+
+function emptyResult(
+  opts: OptimizeOptions,
+  before: AnalysisResult,
+  workingTokenizer: TokenizerId,
+  optimizers: ReturnType<typeof selectOptimizers>,
+  notes: string[],
+): OptimizationResult {
+  return {
+    repoPath: before.repoPath,
+    timestamp: new Date().toISOString(),
+    tokenizer: workingTokenizer,
+    dryRun: Boolean(opts.dryRun),
+    efficiencyGainPct: 0,
+    estimatedTokensSavedPerInvocation: 0,
+    totals: {
+      activeTokensBefore: before.discovery.totalTokens,
+      activeTokensAfter: before.discovery.totalTokens,
+      activeTokensSaved: 0,
+      activeReductionPct: 0,
+      alwaysLoadedTokensBefore: before.discovery.alwaysLoadedTokens,
+      alwaysLoadedTokensAfter: before.discovery.alwaysLoadedTokens,
+      alwaysLoadedTokensSaved: 0,
+      alwaysLoadedReductionPct: 0,
+      filesScanned: 0,
+      filesChanged: 0,
+    },
+    score: {
+      overallBefore: before.score.overall,
+      overallAfter: before.score.overall,
+      gradeBefore: before.score.grade,
+      gradeAfter: before.score.grade,
+      totalFindingsBefore: before.findings.length,
+      totalFindingsAfter: before.findings.length,
+      tokenEfficiencyFindingsBefore: tokenEfficiencyFindings(before),
+      tokenEfficiencyFindingsAfter: tokenEfficiencyFindings(before),
+    },
+    optimizers: optimizers.map(o => ({
+      id: o.id,
+      title: o.title,
+      ruleIds: o.ruleIds,
+      safety: o.safety,
+      description: o.description,
+      filesTouched: 0,
+      tokensSaved: 0,
+    })),
+    files: [],
+    remainingRecommendations: before.recommendations.map(remainingRecommendation),
+    guarantee: {
+      noLossOfFunction: true,
+      method: 'No files were changed.',
+      invariantsChecked: [],
+    },
+    ...(before.experimental ? { experimental: before.experimental } : {}),
+    backups: [],
+    notes,
+  };
+}
+
+export type { OptimizationResult, OptimizeOptions } from './types.js';

--- a/src/optimizer/optimizers.ts
+++ b/src/optimizer/optimizers.ts
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type { OptimizerSafety } from './types.js';
+import { GENERIC_FILLER_PATTERNS } from '../analyzers/token-efficiency.js';
+
+/**
+ * Lossless primitive optimizers.
+ *
+ * Each optimizer is a PURE function `string -> { content, changes }` that only
+ * removes mechanically-redundant or no-op bytes. Together they back the
+ * "100% no loss of function" guarantee: the set of meaningful instructions a
+ * model receives is unchanged — only blank lines, exact duplicates, and
+ * platform-default filler are stripped. The orchestrator independently verifies
+ * this with {@link meaningfulSignature} before writing anything to disk.
+ */
+
+export interface OptimizerEdit {
+  description: string;
+  /** 1-based line in the input content the edit relates to (best-effort). */
+  line?: number;
+}
+
+export interface OptimizerOutput {
+  content: string;
+  edits: OptimizerEdit[];
+}
+
+export interface Optimizer {
+  id: string;
+  title: string;
+  ruleIds: string[];
+  safety: OptimizerSafety;
+  description: string;
+  defaultOn: boolean;
+  apply(content: string): OptimizerOutput;
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+// Hot regexes are hoisted to module scope so they are compiled once rather than
+// re-created on every per-line call across large files.
+const HEADING_RE = /^#{1,6}\s/;
+const TABLE_ROW_RE = /^\|/;
+const PROSE_EXT_RE = /\.(md|mdc|markdown|txt)$/i;
+const PROSE_RULES_RE = /(^|\/)\.(cursorrules|windsurfrules|clinerules)$/i;
+const NON_ALNUM_SPACE_RE = /[^a-z0-9\s]/g; // used only in .replace() (stateless)
+const WS_RUN_RE = /\s+/g;
+const ALNUM_ONLY_RE = /[^a-z0-9]/gi; // .replace() only — safe to share despite /g
+const LIST_MARKER_RE = /^[-*+]\s+/;
+const BLOCKQUOTE_RE = /^>\s+/;
+const ORDERED_MARKER_RE = /^\d+[.)]\s+/;
+const BOLD_WRAP_RE = /^\*\*|\*\*$/g;
+
+/**
+ * Marks every line that is inside a fenced code block (``` or ~~~), including
+ * the fence delimiter lines themselves. Protected lines are NEVER modified, so
+ * code examples keep byte-for-byte fidelity (whitespace can be significant).
+ */
+function protectedMask(lines: string[]): boolean[] {
+  const mask = new Array<boolean>(lines.length).fill(false);
+  let inCode = false;
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i]!.trimStart();
+    const isFence = trimmed.startsWith('```') || trimmed.startsWith('~~~');
+    if (isFence) {
+      mask[i] = true;
+      inCode = !inCode;
+      continue;
+    }
+    mask[i] = inCode;
+  }
+  return mask;
+}
+
+function isHeading(line: string): boolean {
+  return HEADING_RE.test(line.trimStart());
+}
+
+/** Markdown table rows carry positional data; never treat them as duplicates. */
+function isTableRow(line: string): boolean {
+  return TABLE_ROW_RE.test(line.trimStart());
+}
+
+/**
+ * Whether a primitive is free-form prose (Markdown/text/rules) as opposed to a
+ * structured config (JSON/YAML/shell). The content-removing optimizers ONLY run
+ * on prose: in structured files an identical line (e.g. `"type": "string",`) is
+ * usually structurally significant, so removing a "duplicate" would change
+ * meaning — which the signature check cannot detect. Structured primitives are
+ * therefore left untouched, preserving the no-loss guarantee.
+ */
+export function isProseFile(relativePath: string): boolean {
+  return PROSE_EXT_RE.test(relativePath) || PROSE_RULES_RE.test(relativePath);
+}
+
+/** Analyzer-parity normalization used by TE007 duplicate detection. */
+function normalizeForDedupe(line: string): string {
+  return line.trim().toLowerCase().replace(NON_ALNUM_SPACE_RE, '');
+}
+
+/** Collapses a line to its meaningful instruction signature (order-insensitive). */
+export function normLine(line: string): string {
+  return line.trim().toLowerCase().replace(NON_ALNUM_SPACE_RE, '').replace(WS_RUN_RE, ' ').trim();
+}
+
+function truncate(text: string, max = 72): string {
+  const t = text.replace(WS_RUN_RE, ' ').trim();
+  return t.length > max ? `${t.slice(0, max - 1)}…` : t;
+}
+
+/**
+ * Decides whether a line is ENTIRELY platform-default filler (TE003) and may be
+ * dropped without changing agent behavior. A line that merely *contains* a
+ * filler phrase inside a larger, substantive instruction is kept.
+ */
+function standaloneFiller(line: string): { match: boolean; label: string } {
+  const trimmed = line.trim();
+  if (trimmed === '') return { match: false, label: '' };
+  const core = trimmed
+    .replace(LIST_MARKER_RE, '')
+    .replace(BLOCKQUOTE_RE, '')
+    .replace(ORDERED_MARKER_RE, '')
+    .replace(BOLD_WRAP_RE, '');
+
+  let reduced = core;
+  const labels: string[] = [];
+  for (const { pattern, label } of GENERIC_FILLER_PATTERNS) {
+    if (pattern.test(reduced)) {
+      labels.push(label);
+      reduced = reduced.replace(pattern, ' ');
+    }
+  }
+  if (labels.length === 0) return { match: false, label: '' };
+  const remainder = reduced.replace(ALNUM_ONLY_RE, '');
+  // <= 8 leftover alphanumerics ⇒ the line was essentially just filler.
+  if (remainder.length <= 8) return { match: true, label: labels.join('; ') };
+  return { match: false, label: '' };
+}
+
+// ─── Optimizers ──────────────────────────────────────────────────────────────
+
+/** TE007: drop later exact duplicates of a normalized instruction line. */
+function optimizeDedupeLines(content: string): OptimizerOutput {
+  const lines = content.split('\n');
+  const mask = protectedMask(lines);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const edits: OptimizerEdit[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (mask[i] || isHeading(raw) || isTableRow(raw)) {
+      out.push(raw);
+      continue;
+    }
+    const normalized = normalizeForDedupe(raw);
+    if (normalized.length >= 20) {
+      if (seen.has(normalized)) {
+        edits.push({ description: `removed duplicate instruction "${truncate(raw)}"`, line: i + 1 });
+        continue;
+      }
+      seen.add(normalized);
+    }
+    out.push(raw);
+  }
+
+  return { content: out.join('\n'), edits };
+}
+
+/** Remove later byte-identical multi-line instruction blocks within one file. */
+function optimizeDedupeBlocks(content: string): OptimizerOutput {
+  const lines = content.split('\n');
+  const mask = protectedMask(lines);
+  const remove = new Set<number>();
+  const seen = new Map<string, number>();
+  const edits: OptimizerEdit[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    if (mask[i] || lines[i]!.trim() === '') {
+      i++;
+      continue;
+    }
+    const start = i;
+    const para: string[] = [];
+    while (i < lines.length && !mask[i] && lines[i]!.trim() !== '') {
+      para.push(lines[i]!.trim());
+      i++;
+    }
+    if (para.length < 2) continue;
+    const key = para.join('\n');
+    if (key.replace(ALNUM_ONLY_RE, '').length < 30) continue; // ignore trivial blocks
+    const firstLine = seen.get(key);
+    if (firstLine !== undefined) {
+      for (let k = start; k < start + para.length; k++) remove.add(k);
+      edits.push({
+        description: `removed duplicate ${para.length}-line block (first seen at line ${firstLine})`,
+        line: start + 1,
+      });
+    } else {
+      seen.set(key, start + 1);
+    }
+  }
+
+  if (remove.size === 0) return { content, edits: [] };
+  const out = lines.filter((_, idx) => !remove.has(idx));
+  return { content: out.join('\n'), edits };
+}
+
+/** TE003: drop standalone platform-default / no-op filler lines. */
+function optimizeRemoveFiller(content: string): OptimizerOutput {
+  const lines = content.split('\n');
+  const mask = protectedMask(lines);
+  const out: string[] = [];
+  const edits: OptimizerEdit[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (mask[i]) {
+      out.push(raw);
+      continue;
+    }
+    const filler = standaloneFiller(raw);
+    if (filler.match) {
+      edits.push({ description: `removed platform-default filler (${filler.label})`, line: i + 1 });
+      continue;
+    }
+    out.push(raw);
+  }
+
+  return { content: out.join('\n'), edits };
+}
+
+/**
+ * Whitespace hygiene: strip trailing whitespace (preserving markdown hard
+ * breaks), drop leading blank lines, collapse runs of blank lines to one, and
+ * end the file with exactly one newline. Code fences are left untouched.
+ */
+function optimizeWhitespace(content: string): OptimizerOutput {
+  if (content.trim() === '') return { content: '', edits: [] };
+  const lines = content.split('\n');
+  const mask = protectedMask(lines);
+  const out: string[] = [];
+  const edits: OptimizerEdit[] = [];
+  let trailingStripped = 0;
+  let blanksCollapsed = 0;
+  let lastBlank = false;
+  let seenContent = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (mask[i]) {
+      out.push(raw);
+      lastBlank = false;
+      seenContent = true;
+      continue;
+    }
+    if (raw.trim() === '') {
+      if (!seenContent || lastBlank) {
+        blanksCollapsed++;
+        continue;
+      }
+      out.push('');
+      lastBlank = true;
+      continue;
+    }
+    const contentPart = raw.replace(/\s+$/, '');
+    const trailing = raw.slice(contentPart.length);
+    const normalized = /^ {2,}$/.test(trailing) ? `${contentPart}  ` : contentPart;
+    if (normalized !== raw) trailingStripped++;
+    out.push(normalized);
+    lastBlank = false;
+    seenContent = true;
+  }
+
+  // Drop trailing blank lines, then re-add a single terminating newline.
+  while (out.length > 0 && out[out.length - 1] === '') {
+    out.pop();
+    blanksCollapsed++;
+  }
+
+  if (trailingStripped > 0) {
+    edits.push({ description: `stripped trailing whitespace on ${trailingStripped} line(s)` });
+  }
+  if (blanksCollapsed > 0) {
+    edits.push({ description: `collapsed ${blanksCollapsed} redundant blank line(s)` });
+  }
+
+  const result = out.length === 0 ? '' : `${out.join('\n')}\n`;
+  return { content: result, edits };
+}
+
+// ─── Registry ────────────────────────────────────────────────────────────────
+
+/**
+ * Run order matters only for change attribution (all are lossless). Whitespace
+ * runs LAST so it cleans up blank lines left behind by the removal optimizers.
+ */
+export const OPTIMIZERS: Optimizer[] = [
+  {
+    id: 'dedupe-lines',
+    title: 'Remove duplicate instruction lines',
+    ruleIds: ['TE007'],
+    safety: 'lossless',
+    defaultOn: true,
+    description:
+      'Removes later exact duplicates of a normalized instruction line, keeping the first. The instruction still appears once, so behavior is unchanged.',
+    apply: optimizeDedupeLines,
+  },
+  {
+    id: 'dedupe-blocks',
+    title: 'Remove duplicate instruction blocks',
+    ruleIds: ['TE007'],
+    safety: 'lossless',
+    defaultOn: true,
+    description:
+      'Removes later byte-identical multi-line instruction blocks within a file. The block remains in its first location.',
+    apply: optimizeDedupeBlocks,
+  },
+  {
+    id: 'remove-filler',
+    title: 'Remove platform-default filler',
+    ruleIds: ['TE003'],
+    safety: 'lossless',
+    defaultOn: true,
+    description:
+      'Removes standalone lines that only restate model-default behavior (e.g. "You are a helpful assistant"). The model already does these, so removing them changes nothing.',
+    apply: optimizeRemoveFiller,
+  },
+  {
+    id: 'whitespace',
+    title: 'Normalize whitespace',
+    ruleIds: [],
+    safety: 'lossless',
+    defaultOn: true,
+    description:
+      'Strips trailing whitespace (preserving markdown hard breaks), collapses runs of blank lines, and ensures a single trailing newline. Code fences are untouched.',
+    apply: optimizeWhitespace,
+  },
+];
+
+export function selectOptimizers(only?: string[], skip?: string[]): Optimizer[] {
+  const known = new Set(OPTIMIZERS.map(o => o.id));
+  for (const id of [...(only ?? []), ...(skip ?? [])]) {
+    if (!known.has(id)) {
+      throw new Error(`Unknown optimizer "${id}". Known optimizers: ${[...known].join(', ')}.`);
+    }
+  }
+  let chosen = only && only.length > 0
+    ? OPTIMIZERS.filter(o => only.includes(o.id))
+    : OPTIMIZERS.filter(o => o.defaultOn);
+  if (skip && skip.length > 0) {
+    chosen = chosen.filter(o => !skip.includes(o.id));
+  }
+  return chosen;
+}
+
+/**
+ * The deterministic "no loss of function" signature of a primitive: the set of
+ * its meaningful, non-filler instruction lines plus all code verbatim. Two
+ * contents with the same signature deliver the same instructions to a model.
+ * The orchestrator asserts signature(original) === signature(optimized).
+ */
+export function meaningfulSignature(content: string): string {
+  const lines = content.split('\n');
+  const mask = protectedMask(lines);
+  const entries = new Set<string>();
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i]!;
+    if (mask[i]) {
+      entries.add(`CODE:${raw}`);
+      continue;
+    }
+    if (raw.trim() === '') continue;
+    if (standaloneFiller(raw).match) continue;
+    const norm = normLine(raw);
+    entries.add(norm === '' ? `RAW:${raw.trim()}` : `N:${norm}`);
+  }
+  return [...entries].sort().join('\n');
+}

--- a/src/optimizer/report.ts
+++ b/src/optimizer/report.ts
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type { OptimizationResult } from './types.js';
+
+export type OptimizationReportFormat = 'markdown' | 'json';
+
+export function renderOptimizationReport(
+  result: OptimizationResult,
+  format: OptimizationReportFormat,
+): string {
+  return format === 'json' ? JSON.stringify(result, null, 2) : toMarkdown(result);
+}
+
+function n(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function signed(value: number): string {
+  return value > 0 ? `+${n(value)}` : n(value);
+}
+
+function reduction(before: number, after: number): string {
+  const saved = before - after;
+  const pct = before > 0 ? Math.round((saved / before) * 1000) / 10 : 0;
+  return `−${n(saved)} (−${pct}%)`;
+}
+
+function toMarkdown(r: OptimizationResult): string {
+  const lines: string[] = [];
+  const mode = r.dryRun ? 'Dry run (no files written)' : 'Applied';
+
+  lines.push('# CATES Optimization Report');
+  lines.push('');
+  lines.push(`**Repository:** \`${r.repoPath}\``);
+  lines.push(`**Generated:** ${r.timestamp} · **Tokenizer:** ${r.tokenizer} · **Mode:** ${mode}`);
+  lines.push('');
+
+  const headline = r.totals.activeTokensSaved > 0
+    ? `## Result: ${r.efficiencyGainPct}% more token-efficient (−${n(r.totals.activeTokensSaved)} tokens) — guaranteed no loss of function`
+    : '## Result: already optimal — no lossless token savings available';
+  lines.push(headline);
+  lines.push('');
+
+  // Headline table
+  lines.push('| Metric | Before | After | Improvement |');
+  lines.push('| --- | ---: | ---: | ---: |');
+  lines.push(`| Active config tokens | ${n(r.totals.activeTokensBefore)} | ${n(r.totals.activeTokensAfter)} | ${reduction(r.totals.activeTokensBefore, r.totals.activeTokensAfter)} |`);
+  lines.push(`| Always-loaded tokens (per invocation) | ${n(r.totals.alwaysLoadedTokensBefore)} | ${n(r.totals.alwaysLoadedTokensAfter)} | ${reduction(r.totals.alwaysLoadedTokensBefore, r.totals.alwaysLoadedTokensAfter)} |`);
+  lines.push(`| CATES score | ${r.score.overallBefore} (${r.score.gradeBefore}) | ${r.score.overallAfter} (${r.score.gradeAfter}) | ${signed(r.score.overallAfter - r.score.overallBefore)} |`);
+  lines.push(`| Token-efficiency findings | ${r.score.tokenEfficiencyFindingsBefore} | ${r.score.tokenEfficiencyFindingsAfter} | ${signed(r.score.tokenEfficiencyFindingsAfter - r.score.tokenEfficiencyFindingsBefore)} |`);
+  lines.push(`| Total findings | ${r.score.totalFindingsBefore} | ${r.score.totalFindingsAfter} | ${signed(r.score.totalFindingsAfter - r.score.totalFindingsBefore)} |`);
+  lines.push(`| Files changed | — | — | ${r.totals.filesChanged} of ${r.totals.filesScanned} |`);
+  lines.push('');
+
+  if (r.estimatedTokensSavedPerInvocation > 0) {
+    lines.push(`> Always-loaded context is paid on **every** agent invocation, so the ${n(r.estimatedTokensSavedPerInvocation)} tokens removed there are saved on every single request going forward (${r.totals.alwaysLoadedReductionPct}% lighter).`);
+    lines.push('');
+  }
+
+  // Guarantee
+  lines.push(`## ${r.guarantee.noLossOfFunction ? '✅' : '⚠️'} No loss of function`);
+  lines.push('');
+  lines.push(r.guarantee.method);
+  if (r.guarantee.invariantsChecked.length > 0) {
+    lines.push('');
+    lines.push('Invariants verified:');
+    for (const inv of r.guarantee.invariantsChecked) lines.push(`- ${inv}`);
+  }
+  lines.push('');
+
+  // Optimizers applied
+  const applied = r.optimizers.filter(o => o.filesTouched > 0);
+  if (applied.length > 0) {
+    lines.push('## Optimizations applied');
+    lines.push('');
+    lines.push('| Optimizer | Rules | Files | Tokens saved | Safety |');
+    lines.push('| --- | --- | ---: | ---: | --- |');
+    for (const o of applied) {
+      lines.push(`| ${o.title} | ${o.ruleIds.join(', ') || '—'} | ${o.filesTouched} | ${n(o.tokensSaved)} | ${o.safety} |`);
+    }
+    lines.push('');
+  }
+
+  // Files changed
+  const changed = r.files.filter(f => f.changed && f.functionPreserved);
+  if (changed.length > 0) {
+    lines.push('## Files changed');
+    lines.push('');
+    for (const f of changed) {
+      lines.push(`### \`${f.relativePath}\``);
+      lines.push(`*${f.scope} · ${f.type}* — ${reduction(f.tokensBefore, f.tokensAfter)} tokens (${n(f.tokensBefore)} → ${n(f.tokensAfter)})`);
+      for (const c of f.changes) {
+        const where = c.line !== undefined ? ` _(line ${c.line})_` : '';
+        lines.push(`- ${c.description}${where}`);
+      }
+      lines.push('');
+    }
+  }
+
+  // Reverted files (should be none)
+  const reverted = r.files.filter(f => !f.functionPreserved);
+  if (reverted.length > 0) {
+    lines.push('## Reverted (safety net triggered)');
+    lines.push('');
+    for (const f of reverted) {
+      lines.push(`- \`${f.relativePath}\` — ${f.reverted ?? 'meaningful content would have changed'} (left untouched)`);
+    }
+    lines.push('');
+  }
+
+  // Remaining opportunities
+  if (r.remainingRecommendations.length > 0) {
+    lines.push('## Remaining opportunities (need human review)');
+    lines.push('');
+    lines.push('These were **not** auto-applied because doing so safely needs human judgement:');
+    lines.push('');
+    for (const rec of r.remainingRecommendations) {
+      const save = rec.tokenSavings > 0 ? ` · ~${n(rec.tokenSavings)} tokens` : '';
+      const rules = rec.ruleIds.length > 0 ? ` [${rec.ruleIds.join(', ')}]` : '';
+      lines.push(`- **${rec.title}**${rules}${save} · effort: ${rec.effort}`);
+      lines.push(`  - ${rec.reason}`);
+    }
+    lines.push('');
+  }
+
+  if (r.backups.length > 0) {
+    lines.push('## Backups');
+    lines.push('');
+    for (const b of r.backups) lines.push(`- \`${b}\``);
+    lines.push('');
+  }
+
+  if (r.experimental) {
+    const xp = r.experimental;
+    lines.push('## 🧪 Experimental opportunities (advisory — NOT auto-applied)');
+    lines.push('');
+    lines.push('These cache/output-shaping smells fall **outside the lossless guarantee** (fixing them changes behavior), so the optimizer never touches them. Shown so you can see the wider token impact.');
+    lines.push('');
+    for (const dim of xp.dimensions) {
+      lines.push(`- **${dim.dimension}** — ${dim.findings.length} finding(s), ~${n(dim.estimatedTokenImpact)} est. tokens`);
+    }
+    lines.push(`- **Estimated total token impact (advisory):** ~${n(xp.estimatedTokenImpact)} tokens`);
+    if (xp.findings.length > 0) {
+      lines.push('');
+      lines.push('| Rule | Severity | File | Token class | Finding |');
+      lines.push('| --- | --- | --- | --- | --- |');
+      for (const f of xp.findings) {
+        const where = `${f.file}${f.line ? ':' + f.line : ''}`;
+        lines.push(`| ${f.ruleId} | ${f.severity} | \`${where}\` | ${f.tokenClass ?? '—'} | ${f.message.replace(/\|/g, '\\|')} |`);
+      }
+    }
+    lines.push('');
+    lines.push(`> ${xp.note}`);
+    lines.push('');
+  }
+
+  if (r.notes.length > 0) {
+    lines.push('## Notes');
+    lines.push('');
+    for (const note of r.notes) lines.push(`- ${note}`);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import type { AnalysisResult, ConfigScope, ConfigType, ExperimentalReport, Suppression } from '../types.js';
+import type { TokenizerId } from '../utils/tokenizer.js';
+
+/**
+ * Every optimizer the tool ships is `lossless`: it only removes mechanically
+ * redundant or no-op bytes (blank lines, exact duplicate instructions,
+ * platform-default filler) and never rewrites or reorders meaningful guidance.
+ * This is what backs the tool's "100% no loss of function" guarantee — a
+ * property that can be checked deterministically, unlike an LLM rewrite.
+ */
+export type OptimizerSafety = 'lossless';
+
+/** A single concrete edit an optimizer made to one file. */
+export interface OptimizerChangeRecord {
+  optimizerId: string;
+  ruleIds: string[];
+  description: string;
+  /** 1-based line in the ORIGINAL file the change relates to (best-effort). */
+  line?: number;
+}
+
+/** Per-file optimization outcome. */
+export interface FileOptimization {
+  relativePath: string;
+  type: ConfigType;
+  scope: ConfigScope;
+  changed: boolean;
+  tokensBefore: number;
+  tokensAfter: number;
+  tokensSaved: number;
+  bytesBefore: number;
+  bytesAfter: number;
+  changes: OptimizerChangeRecord[];
+  /** True when the no-loss invariant held and the edit was kept. */
+  functionPreserved: boolean;
+  /** Populated only when an edit was reverted because the invariant failed. */
+  reverted?: string;
+}
+
+/** Aggregate token totals before and after optimization. */
+export interface OptimizationTotals {
+  activeTokensBefore: number;
+  activeTokensAfter: number;
+  activeTokensSaved: number;
+  /** % of active config tokens removed (the headline efficiency gain). */
+  activeReductionPct: number;
+  alwaysLoadedTokensBefore: number;
+  alwaysLoadedTokensAfter: number;
+  alwaysLoadedTokensSaved: number;
+  /** % of always-loaded tokens removed (saved on EVERY invocation). */
+  alwaysLoadedReductionPct: number;
+  filesScanned: number;
+  filesChanged: number;
+}
+
+/** CATES score / findings movement caused by the optimization. */
+export interface ScoreDelta {
+  overallBefore: number;
+  overallAfter: number;
+  gradeBefore: string;
+  gradeAfter: string;
+  totalFindingsBefore: number;
+  totalFindingsAfter: number;
+  tokenEfficiencyFindingsBefore: number;
+  tokenEfficiencyFindingsAfter: number;
+}
+
+/**
+ * A CATES recommendation the optimizer deliberately did NOT auto-apply because
+ * doing so safely requires human judgement (restructuring, rescoping, rewriting)
+ * and therefore falls outside the lossless guarantee.
+ */
+export interface RemainingRecommendation {
+  title: string;
+  ruleIds: string[];
+  files: string[];
+  tokenSavings: number;
+  effort: string;
+  safety: string;
+  reason: string;
+}
+
+/** Metadata describing one optimizer, surfaced in the report. */
+export interface AppliedOptimizerInfo {
+  id: string;
+  title: string;
+  ruleIds: string[];
+  safety: OptimizerSafety;
+  description: string;
+  filesTouched: number;
+  tokensSaved: number;
+}
+
+/** The achievement report the tool produces. */
+export interface OptimizationResult {
+  repoPath: string;
+  timestamp: string;
+  tokenizer: string;
+  dryRun: boolean;
+  /** Headline: % of active config tokens removed with no loss of function. */
+  efficiencyGainPct: number;
+  /** Always-loaded tokens removed — the recurring per-invocation saving. */
+  estimatedTokensSavedPerInvocation: number;
+  totals: OptimizationTotals;
+  score: ScoreDelta;
+  optimizers: AppliedOptimizerInfo[];
+  files: FileOptimization[];
+  remainingRecommendations: RemainingRecommendation[];
+  guarantee: {
+    noLossOfFunction: boolean;
+    method: string;
+    invariantsChecked: string[];
+  };
+  /**
+   * Experimental (non-normative) cache/output-shaping posture, present only when
+   * run with experimental mode. ADVISORY — these are never auto-applied (they
+   * require human judgement and would change behavior), so they fall outside the
+   * lossless guarantee. Shown so users can see the wider token impact.
+   */
+  experimental?: ExperimentalReport;
+  /** Sibling `.orig` backups written, when --backup is set. */
+  backups: string[];
+  notes: string[];
+}
+
+export interface OptimizeOptions {
+  repoPath: string;
+  /** Reuse a prior `cates-analyzer --format json` report instead of re-analyzing. */
+  report?: AnalysisResult;
+  tokenizer?: TokenizerId;
+  dryRun?: boolean;
+  backup?: boolean;
+  /** Whitelist of optimizer ids to run (defaults to all default-on optimizers). */
+  only?: string[];
+  /** Optimizer ids to skip. */
+  skip?: string[];
+  maxFiles?: number;
+  maxDepth?: number;
+  suppressions?: Suppression[];
+  /** Surface experimental (non-normative) cache/output-shaping token impact (advisory). */
+  experimental?: boolean;
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -22,6 +22,8 @@ export interface CatesPolicy {
   suppressions?: Suppression[];
   rules?: RuleConfigMap;
   dimensions?: DimensionConfigMap;
+  /** Opt in to experimental (non-normative) cache/output-shaping analysis. */
+  experimental?: boolean;
 }
 
 export const DEFAULT_POLICY: Required<Pick<CatesPolicy, 'minScore' | 'requireLevel' | 'failOn' | 'maxAlwaysLoadedTokens'>> = {
@@ -63,6 +65,7 @@ function normalizePolicy(value: unknown): CatesPolicy {
       : undefined,
     rules: parseRuleMap(input['rules']),
     dimensions: parseDimensionMap(input['dimensions']),
+    experimental: typeof input['experimental'] === 'boolean' ? input['experimental'] : undefined,
   };
 }
 

--- a/src/rules/catalog.ts
+++ b/src/rules/catalog.ts
@@ -1,17 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import type { Dimension, Severity } from '../types.js';
+import type { Dimension, ExperimentalDimension, Severity, Stability } from '../types.js';
 
 export interface RuleMetadata {
   id: string;
   title: string;
-  dimension: Dimension;
+  dimension: Dimension | ExperimentalDimension;
   severity: Severity;
   summary: string;
   detection: string;
   remediation: string;
   catesSection: string;
   autofix?: boolean;
+  /** Defaults to 'stable'. Experimental rules are non-normative and SemVer-exempt. */
+  stability?: Stability;
 }
 
 export const RULE_CATALOG: RuleMetadata[] = [
@@ -74,10 +76,35 @@ export const RULE_CATALOG: RuleMetadata[] = [
   { id: 'AGT002', title: 'Subagent Missing Description', dimension: 'specificity', severity: 'low', summary: 'Subagent lacks a description/trigger for routing.', detection: 'Flag agent-definition files with no description/name/purpose metadata or heading.', remediation: 'Add a description (and name) stating when the subagent should be invoked.', catesSection: '9.8', autofix: false },
 
   { id: 'CMD001', title: 'Command Auto-Executes Shell', dimension: 'security', severity: 'high', summary: 'Slash command runs shell on invocation via bang-syntax or a Bash tool grant.', detection: 'Flag command files with !-prefixed execution directives or allowed-tools granting Bash.', remediation: 'Remove side-effect shell execution or constrain it to a fixed, non-parameterized command.', catesSection: '9.8', autofix: false },
+
+  // ─── Experimental (non-normative) cache/output-shaping rules ─────────────────
+  // These carry ZERO scoring weight, are excluded from conformance + CI gates,
+  // and are SemVer-exempt. See docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md.
+  { id: 'CS001', title: 'Volatile Tokens in Always-Loaded Config', dimension: 'cache-shaping', severity: 'high', summary: 'Always-loaded config embeds volatile values (dates, UUIDs, build numbers, git SHAs) that bust the cacheable prefix every call.', detection: 'Scan always-loaded files for timestamp/date/UUID/build/SHA patterns or "current date/time" directives.', remediation: 'Move volatile values out of the always-loaded prefix; inject them via tool inputs at the end of context instead.', catesSection: '9.9', autofix: false, stability: 'experimental' },
+  { id: 'CS002', title: 'Dynamic-Before-Static Ordering', dimension: 'cache-shaping', severity: 'medium', summary: 'Variable placeholders or includes appear ahead of a large static block, shrinking the cacheable prefix.', detection: 'Detect ${…}/{{…}}/@include placeholders positioned before the bulk of static content.', remediation: 'Put stable, static content first; place variable/dynamic content at the end.', catesSection: '9.9', autofix: false, stability: 'experimental' },
+  { id: 'CS003', title: 'Non-Deterministic Context Directive', dimension: 'cache-shaping', severity: 'medium', summary: 'Instructions inject live/volatile state at the top (current git status, latest logs, today\'s date).', detection: 'Match directives that pull live/volatile state into the preamble.', remediation: 'Fetch volatile state on-demand via tools rather than embedding it in always-loaded instructions.', catesSection: '9.9', autofix: false, stability: 'experimental' },
+  { id: 'CS004', title: 'Unstable Tool/Context Ordering', dimension: 'cache-shaping', severity: 'low', summary: 'Directives randomize or re-sort tool lists / retrieved context per call.', detection: 'Match shuffle/randomize/re-sort directives over tools or context.', remediation: 'Keep tool and context ordering stable and deterministic across calls.', catesSection: '9.9', autofix: false, stability: 'experimental' },
+  { id: 'CS005', title: 'Fragmented Preamble (No Shared Prelude)', dimension: 'cache-shaping', severity: 'info', summary: 'High cross-file near-duplication of preamble that could be one shared cacheable prelude.', detection: 'Correlate with TE006 cross-file duplication of leading preamble blocks.', remediation: 'Hoist the shared preamble into a single, stable, precedence-appropriate prelude.', catesSection: '9.9', autofix: false, stability: 'experimental' },
+
+  { id: 'OS001', title: 'Missing Output Contract', dimension: 'output-shaping', severity: 'medium', summary: 'Config never bounds output (no length cap, no code-only/no-preamble, no format spec).', detection: 'Flag instruction-bearing configs that set no output bound or format contract.', remediation: 'Add a concise output contract (length cap, "code only, no preamble", or required format).', catesSection: '9.10', autofix: false, stability: 'experimental' },
+  { id: 'OS002', title: 'Full-File Rewrite Mandate', dimension: 'output-shaping', severity: 'high', summary: 'Instructions require emitting entire files instead of diffs/patches — large, avoidable output.', detection: 'Match "return/output the complete/entire file" style mandates.', remediation: 'Prefer diffs/patches or targeted edits; reserve full-file output for new files.', catesSection: '9.10', autofix: false, stability: 'experimental' },
+  { id: 'OS003', title: 'Unconditional Verbose Reasoning', dimension: 'output-shaping', severity: 'medium', summary: 'Forces detailed chain-of-thought/explanation on every response regardless of task.', detection: 'Match unconditional "explain your reasoning / think step by step on every response" directives.', remediation: 'Make reasoning depth conditional on task complexity rather than global.', catesSection: '9.10', autofix: false, stability: 'experimental' },
+  { id: 'OS004', title: 'Output Echo / Restatement', dimension: 'output-shaping', severity: 'low', summary: 'Instructs the agent to restate the prompt, echo inputs, or repeat context back.', detection: 'Match restate/echo/repeat-back directives.', remediation: 'Remove echo/restatement requirements; have the agent act directly.', catesSection: '9.10', autofix: false, stability: 'experimental' },
+  { id: 'OS005', title: 'Verbose Format Mandate', dimension: 'output-shaping', severity: 'info', summary: 'Requires heavyweight formatting (decorative sections, full tables) where compact output suffices.', detection: 'Match mandates for heavyweight/decorative formatting on every response.', remediation: 'Default to compact output; reserve rich formatting for when it is requested.', catesSection: '9.10', autofix: false, stability: 'experimental' },
 ];
 
 export function getRule(id: string): RuleMetadata | undefined {
   return RULE_CATALOG.find(rule => rule.id === id);
+}
+
+/** Stable rules only — the normative catalog used for scoring/conformance. */
+export function stableRules(): RuleMetadata[] {
+  return RULE_CATALOG.filter(rule => rule.stability !== 'experimental');
+}
+
+/** Experimental, non-normative rules (cache/output shaping). */
+export function experimentalRules(): RuleMetadata[] {
+  return RULE_CATALOG.filter(rule => rule.stability === 'experimental');
 }
 
 export function rulesAsJson(): string {

--- a/src/scoring/report.ts
+++ b/src/scoring/report.ts
@@ -151,12 +151,57 @@ function toPretty(result: AnalysisResult): string {
     }
   }
 
+  if (result.experimental) {
+    lines.push(...experimentalLines(result));
+  }
+
   lines.push('─'.repeat(62));
   lines.push(`  Analyzed: ${result.repoPath}`);
   lines.push(`  Timestamp: ${result.timestamp}`);
   lines.push('');
 
   return lines.join('\n');
+}
+
+/**
+ * Renders the isolated experimental (cache/output-shaping) block. Clearly
+ * labeled as non-scored and subject to change. Empty when experimental mode is
+ * off (no `result.experimental`).
+ */
+export function formatExperimental(result: AnalysisResult): string {
+  if (!result.experimental) {
+    return '🧪 Experimental mode is off. Re-run with --experimental to see cache/output-shaping findings.';
+  }
+  return experimentalLines(result).join('\n');
+}
+
+function experimentalLines(result: AnalysisResult): string[] {
+  const xp = result.experimental;
+  if (!xp) return [];
+  const icons: Record<string, string> = { critical: '🔴', high: '🟠', medium: '🟡', low: '🔵', info: 'ℹ️' };
+  const lines: string[] = [];
+  lines.push('  🧪 Experimental — NOT scored, excluded from conformance & CI, subject to change');
+  for (const dim of xp.dimensions) {
+    lines.push(`     ${padRight(dim.dimension, 16)} ${dim.findings.length} finding(s)   ~${dim.estimatedTokenImpact.toLocaleString()} est. tokens`);
+  }
+  lines.push(`     Estimated token impact (advisory): ~${xp.estimatedTokenImpact.toLocaleString()} tokens`);
+  if (xp.findings.length > 0) {
+    lines.push('');
+    const ordered = [...xp.findings].sort((a, b) => severityRank(a.severity) - severityRank(b.severity));
+    for (const f of ordered) {
+      const icon = icons[f.severity] ?? '•';
+      const cls = f.tokenClass ? ` [${f.tokenClass}]` : '';
+      lines.push(`     ${icon} [${f.ruleId}] ${f.message}`);
+      lines.push(`       └─ ${f.file}${f.line ? ':' + f.line : ''}${cls}`);
+      if (f.suggestion) lines.push(`       💡 ${f.suggestion}`);
+    }
+  } else {
+    lines.push('     ✓ No experimental cache/output-shaping smells detected.');
+  }
+  lines.push('');
+  lines.push(`     ${xp.note}`);
+  lines.push('');
+  return lines;
 }
 
 function toSarif(result: AnalysisResult): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,14 @@ export type Dimension =
   | 'conflict-reachability'
   | 'harness-quality';
 
+// ─── Experimental (non-normative) ────────────────────────────────────────────
+// Experimental dimensions are deliberately a SEPARATE type from `Dimension` so
+// they can never enter `Record<Dimension, …>` scoring weights — the strongest
+// possible isolation. They carry zero scoring weight and are excluded from
+// conformance/CI gates. See docs/EXPERIMENTAL-CACHE-OUTPUT-DIMENSIONS.md.
+export type ExperimentalDimension = 'cache-shaping' | 'output-shaping';
+export type Stability = 'stable' | 'experimental';
+
 export interface Finding {
   ruleId: string;
   dimension: Dimension;
@@ -26,6 +34,39 @@ export interface Finding {
   evidence?: string;
   suggestion?: string;
   tokenImpact?: number; // estimated tokens saved if fixed
+}
+
+/**
+ * An experimental finding. Structurally a Finding but on an experimental
+ * dimension and explicitly stability-marked. These NEVER appear in
+ * `AnalysisResult.findings`; they live only under `AnalysisResult.experimental`.
+ */
+export interface ExperimentalFinding extends Omit<Finding, 'dimension'> {
+  dimension: ExperimentalDimension;
+  stability: 'experimental';
+  /** Which token class the impact estimate refers to (advisory). */
+  tokenClass?: 'cached-input' | 'output';
+}
+
+export interface ExperimentalDimensionScore {
+  dimension: ExperimentalDimension;
+  score: number; // 0-100, display only — carries weight 0, never folded into overall
+  findings: ExperimentalFinding[];
+  estimatedTokenImpact: number; // advisory sum of finding tokenImpact
+  summary: string;
+}
+
+/**
+ * The isolated experimental channel. Present on AnalysisResult only when
+ * experimental mode is enabled. Automation must treat everything here as
+ * non-normative and SemVer-exempt.
+ */
+export interface ExperimentalReport {
+  enabled: boolean;
+  findings: ExperimentalFinding[];
+  dimensions: ExperimentalDimensionScore[];
+  estimatedTokenImpact: number;
+  note: string;
 }
 
 export interface Suppression {
@@ -141,6 +182,12 @@ export interface AnalysisResult {
   disabledFindings?: Finding[];
   disabledRuleIds?: string[];
   disabledDimensions?: Dimension[];
+  /**
+   * Experimental, non-normative channel (cache-shaping / output-shaping).
+   * Present only when experimental mode is enabled. Carries zero scoring weight
+   * and is excluded from conformance and CI gates.
+   */
+  experimental?: ExperimentalReport;
 }
 
 export interface Recommendation {
@@ -196,6 +243,9 @@ export const AnalyzerOptionsSchema = z.object({
       severity: z.enum(['critical', 'high', 'medium', 'low', 'info']).optional(),
     }),
   ).default({}),
+  // Experimental (non-normative) cache/output-shaping analysis. Off by default.
+  // When false, the experimental analyzers are not run at all (no wasted work).
+  experimental: z.boolean().default(false),
 });
 
 export type AnalyzerOptions = z.infer<typeof AnalyzerOptionsSchema>;

--- a/tests/catalog-and-exports.test.ts
+++ b/tests/catalog-and-exports.test.ts
@@ -1,12 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { describe, it, expect } from 'vitest';
-import { RULE_CATALOG, getRule, rulesAsJson } from '../src/rules/catalog.js';
+import { RULE_CATALOG, getRule, rulesAsJson, stableRules, experimentalRules } from '../src/rules/catalog.js';
 import * as lib from '../src/index.js';
 
 describe('rules/catalog', () => {
-  it('has 49 rules (the documented count)', () => {
-    expect(RULE_CATALOG).toHaveLength(49);
+  it('has 49 stable rules and 10 experimental rules (the documented counts)', () => {
+    expect(stableRules()).toHaveLength(49);
+    expect(experimentalRules()).toHaveLength(10);
+    expect(RULE_CATALOG).toHaveLength(59);
+  });
+
+  it('experimental rules are all CS/OS and marked stability experimental', () => {
+    for (const rule of experimentalRules()) {
+      expect(rule.id).toMatch(/^(CS|OS)\d{3}$/);
+      expect(rule.stability).toBe('experimental');
+      expect(['cache-shaping', 'output-shaping']).toContain(rule.dimension);
+    }
+    // Stable rules must never be on an experimental dimension.
+    for (const rule of stableRules()) {
+      expect(rule.stability ?? 'stable').toBe('stable');
+    }
   });
 
   it('getRule returns metadata for known ids and undefined for unknown', () => {

--- a/tests/experimental.test.ts
+++ b/tests/experimental.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { analyzeInMemory } from '../src/analyze-in-memory.js';
+import { evaluateConformance } from '../src/conformance.js';
+import { formatExperimental } from '../src/scoring/report.js';
+import { optimize } from '../src/optimizer/index.js';
+import { renderOptimizationReport } from '../src/optimizer/report.js';
+import type { AnalysisResult } from '../src/types.js';
+
+const INSTRUCTIONS = '.github/copilot-instructions.md';
+
+// A primitive exhibiting several cache- and output-shaping smells at once.
+const SMELLY = [
+  '# Service Agent',
+  '',
+  "Today's date is relevant. Build #4821 is current.",
+  '',
+  '## Stack',
+  'TypeScript service using Drizzle ORM and Zod across the src directory for validation here.',
+  '',
+  '## Behavior',
+  '- Always explain your reasoning step by step on every response.',
+  '- When editing, return the complete file contents in your reply.',
+  '- Restate the prompt back before answering the question.',
+  '- Always use a comprehensive summary table for each response.',
+  '- Always include the current git status at the top of context.',
+  '',
+].join('\n');
+
+async function analyzeSmelly(experimental: boolean, extra: Record<string, unknown> = {}): Promise<AnalysisResult> {
+  return analyzeInMemory({ files: [{ path: INSTRUCTIONS, content: SMELLY }], experimental, ...extra } as Parameters<typeof analyzeInMemory>[0]);
+}
+
+describe('experimental isolation guardrails (the critical ones)', () => {
+  it('overall score and grade are IDENTICAL with and without experimental', async () => {
+    const base = await analyzeSmelly(false);
+    const xp = await analyzeSmelly(true);
+    expect(xp.score.overall).toBe(base.score.overall);
+    expect(xp.score.grade).toBe(base.score.grade);
+    // every stable dimension score is byte-identical too
+    expect(xp.score.dimensions.map(d => d.score)).toEqual(base.score.dimensions.map(d => d.score));
+  });
+
+  it('conformance is IDENTICAL with experimental on', async () => {
+    const base = await analyzeSmelly(false);
+    const xp = await analyzeSmelly(true);
+    expect(evaluateConformance(xp)).toEqual(evaluateConformance(base));
+  });
+
+  it('result.findings NEVER contains an experimental (CS/OS) finding', async () => {
+    const xp = await analyzeSmelly(true);
+    expect(xp.findings.some(f => /^(CS|OS)\d/.test(f.ruleId))).toBe(false);
+    expect(xp.findings.some(f => (f as { stability?: string }).stability === 'experimental')).toBe(false);
+  });
+
+  it('experimental channel is absent unless enabled', async () => {
+    const base = await analyzeSmelly(false);
+    expect(base.experimental).toBeUndefined();
+    const xp = await analyzeSmelly(true);
+    expect(xp.experimental?.enabled).toBe(true);
+  });
+});
+
+describe('cache-shaping detectors (CS0xx)', () => {
+  it('CS001 flags volatile tokens in always-loaded config', async () => {
+    const xp = await analyzeSmelly(true);
+    const cs001 = xp.experimental!.findings.find(f => f.ruleId === 'CS001');
+    expect(cs001).toBeDefined();
+    expect(cs001!.tokenClass).toBe('cached-input');
+    expect(cs001!.dimension).toBe('cache-shaping');
+  });
+
+  it('CS003 flags live-state directives in the preamble', async () => {
+    const xp = await analyzeSmelly(true);
+    expect(xp.experimental!.findings.some(f => f.ruleId === 'CS003')).toBe(true);
+  });
+
+  it('CS002 flags a variable placeholder ahead of a large static block', async () => {
+    const big = Array.from({ length: 60 }, (_, i) => `- Convention number ${i} about the codebase structure and testing approach used here.`).join('\n');
+    const content = `# Template\n\nContext: \${USER_REQUEST}\n\n## Standards\n${big}\n`;
+    const r = await analyzeInMemory({ files: [{ path: INSTRUCTIONS, content }], experimental: true });
+    expect(r.experimental!.findings.some(f => f.ruleId === 'CS002')).toBe(true);
+  });
+
+  it('CS004 flags unstable tool/context ordering directives', async () => {
+    const content = '# Agent\n\nShuffle the tool list on each call to add variety to results.\n';
+    const r = await analyzeInMemory({ files: [{ path: INSTRUCTIONS, content }], experimental: true });
+    expect(r.experimental!.findings.some(f => f.ruleId === 'CS004')).toBe(true);
+  });
+
+  it('CS005 flags a fragmented preamble shared across files', async () => {
+    const shared = [
+      'This repository is a TypeScript service.',
+      'All code must be strictly linted before every commit.',
+      'Full unit test coverage is required across the codebase.',
+    ].join('\n');
+    const r = await analyzeInMemory({
+      files: [
+        { path: INSTRUCTIONS, content: `# A\n\n${shared}\n\nUse Drizzle ORM.\n` },
+        { path: 'AGENTS.md', content: `# B\n\n${shared}\n\nUse Vitest for tests.\n` },
+      ],
+      experimental: true,
+    });
+    expect(r.experimental!.findings.some(f => f.ruleId === 'CS005')).toBe(true);
+  });
+});
+
+describe('output-shaping detectors (OS0xx)', () => {
+  it('flags OS002 (full file), OS003 (verbose reasoning), OS004 (echo), OS005 (verbose format)', async () => {
+    const xp = await analyzeSmelly(true);
+    const ids = new Set(xp.experimental!.findings.map(f => f.ruleId));
+    expect(ids.has('OS002')).toBe(true);
+    expect(ids.has('OS003')).toBe(true);
+    expect(ids.has('OS004')).toBe(true);
+    expect(ids.has('OS005')).toBe(true);
+    for (const f of xp.experimental!.findings.filter(f => f.ruleId.startsWith('OS'))) {
+      expect(f.tokenClass).toBe('output');
+    }
+  });
+
+  it('OS001 flags a substantial instruction file with no output contract; clean files produce nothing', async () => {
+    const big = Array.from({ length: 40 }, (_, i) => `- Rule ${i}: keep modules small and cohesive across the service codebase.`).join('\n');
+    const noContract = `# Agent\n\n## Rules\n${big}\n`;
+    const withContract = `# Agent\n\nBe concise; code only, no preamble.\n\n## Rules\n${big}\n`;
+    const a = await analyzeInMemory({ files: [{ path: INSTRUCTIONS, content: noContract }], experimental: true });
+    const b = await analyzeInMemory({ files: [{ path: INSTRUCTIONS, content: withContract }], experimental: true });
+    expect(a.experimental!.findings.some(f => f.ruleId === 'OS001')).toBe(true);
+    expect(b.experimental!.findings.some(f => f.ruleId === 'OS001')).toBe(false);
+  });
+
+  it('clean config yields no experimental findings', async () => {
+    const clean = '# Agent\n\nBe concise; code only, no preamble.\n\nUse TypeScript and Vitest for tests.\n';
+    const r = await analyzeInMemory({ files: [{ path: INSTRUCTIONS, content: clean }], experimental: true });
+    expect(r.experimental!.findings).toHaveLength(0);
+    expect(r.experimental!.estimatedTokenImpact).toBe(0);
+  });
+});
+
+describe('experimental rule overrides + report', () => {
+  it('rules[id] = off removes an experimental finding; severity override applies', async () => {
+    const off = await analyzeSmelly(true, { rules: { OS002: { enabled: false } } });
+    expect(off.experimental!.findings.some(f => f.ruleId === 'OS002')).toBe(false);
+    const soft = await analyzeSmelly(true, { rules: { CS001: { severity: 'low' } } });
+    expect(soft.experimental!.findings.find(f => f.ruleId === 'CS001')?.severity).toBe('low');
+  });
+
+  it('formatExperimental renders a labeled section, or an off message', async () => {
+    const xp = await analyzeSmelly(true);
+    expect(formatExperimental(xp)).toMatch(/Experimental — NOT scored/);
+    expect(formatExperimental(xp)).toMatch(/cache-shaping/);
+    const base = await analyzeSmelly(false);
+    expect(formatExperimental(base)).toMatch(/Experimental mode is off/);
+  });
+});
+
+describe('optimizer experimental mode', () => {
+  let repo: string;
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'cates-xp-opt-'));
+    await mkdir(join(repo, '.github'), { recursive: true });
+    await writeFile(join(repo, INSTRUCTIONS), SMELLY, 'utf-8');
+  });
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('surfaces experimental token impact without auto-applying it', async () => {
+    const plain = await optimize({ repoPath: repo, dryRun: true });
+    expect(plain.experimental).toBeUndefined();
+
+    const result = await optimize({ repoPath: repo, dryRun: true, experimental: true });
+    expect(result.experimental?.enabled).toBe(true);
+    expect(result.experimental!.estimatedTokenImpact).toBeGreaterThan(0);
+    const md = renderOptimizationReport(result, 'markdown');
+    expect(md).toMatch(/Experimental opportunities/);
+    expect(md).toMatch(/NOT auto-applied/);
+  });
+});

--- a/tests/optimizer.test.ts
+++ b/tests/optimizer.test.ts
@@ -1,0 +1,355 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, readFile, rm, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { analyze } from '../src/analyzers/index.js';
+import { optimize } from '../src/optimizer/index.js';
+import {
+  OPTIMIZERS,
+  selectOptimizers,
+  meaningfulSignature,
+  type Optimizer,
+} from '../src/optimizer/optimizers.js';
+import { renderOptimizationReport } from '../src/optimizer/report.js';
+
+function byId(id: string): Optimizer {
+  const found = OPTIMIZERS.find(o => o.id === id);
+  if (!found) throw new Error(`no optimizer ${id}`);
+  return found;
+}
+
+const INSTRUCTIONS = '.github/copilot-instructions.md';
+
+// A primitive that is inefficient in losslessly-fixable ways (filler + an exact
+// duplicate instruction + blank-line spam) AND in ways that require human
+// judgement (forced verbosity → TE004, which must NOT be auto-applied).
+const MESSY = [
+  '# Team Guidelines',
+  '',
+  'You are a helpful assistant. Please be concise.',
+  '',
+  '## Conventions',
+  '',
+  '- Use `const` by default and only reach for `let` when reassignment is required.',
+  '- Validate every inbound request body with the Zod schemas under `src/schemas`.',
+  '- Use `const` by default and only reach for `let` when reassignment is required.',
+  '',
+  '',
+  '',
+  '## Output',
+  '',
+  '- Always explain every code change in detail with comprehensive comments.',
+  '',
+].join('\n');
+
+describe('optimizers (pure, lossless)', () => {
+  it('whitespace: strips trailing ws, keeps hard breaks, collapses blanks, preserves code', () => {
+    const input = [
+      '',
+      'First line.   ',
+      'Second line. ',
+      '',
+      '',
+      '',
+      '```',
+      'code   with   spaces   ',
+      '```',
+      '',
+      '',
+    ].join('\n');
+    const out = byId('whitespace').apply(input);
+    expect(out.content).toBe(
+      'First line.  \nSecond line.\n\n```\ncode   with   spaces   \n```\n',
+    );
+    expect(meaningfulSignature(input)).toBe(meaningfulSignature(out.content));
+  });
+
+  it('whitespace: empty content stays empty', () => {
+    expect(byId('whitespace').apply('   \n\n').content).toBe('');
+  });
+
+  it('dedupe-lines: removes later exact duplicate, keeps first, ignores short lines and code', () => {
+    const input = [
+      '# Heading',
+      'Run the full integration test suite before pushing to the main branch.',
+      'short one',
+      'short one',
+      'Run the full integration test suite before pushing to the main branch.',
+      '```',
+      'duplicate code line that is quite long but lives inside a fence block',
+      'duplicate code line that is quite long but lives inside a fence block',
+      '```',
+    ].join('\n');
+    const out = byId('dedupe-lines').apply(input);
+    const lines = out.content.split('\n');
+    expect(lines.filter(l => l.startsWith('Run the full integration')).length).toBe(1);
+    // short lines (normalized < 20 chars) are left untouched
+    expect(lines.filter(l => l === 'short one').length).toBe(2);
+    // code-fence duplicates are preserved verbatim
+    expect(lines.filter(l => l.includes('duplicate code line')).length).toBe(2);
+    expect(meaningfulSignature(input)).toBe(meaningfulSignature(out.content));
+  });
+
+  it('dedupe-blocks: removes later byte-identical multi-line block', () => {
+    const block = [
+      'When generating migrations, always include a reversible down step.',
+      'Name the migration file with the UTC timestamp prefix used by the toolchain.',
+    ];
+    const input = [
+      ...block,
+      '',
+      'A unique separating paragraph that should remain in place untouched here.',
+      '',
+      ...block,
+      '',
+    ].join('\n');
+    const out = byId('dedupe-blocks').apply(input);
+    expect(out.content.split('reversible down step').length - 1).toBe(1);
+    expect(out.edits.length).toBe(1);
+    expect(meaningfulSignature(input)).toBe(meaningfulSignature(out.content));
+  });
+
+  it('dedupe-blocks: ignores trivial short blocks', () => {
+    const input = '- a\n- b\n\n- a\n- b\n';
+    const out = byId('dedupe-blocks').apply(input);
+    expect(out.edits).toEqual([]);
+    expect(out.content).toBe(input);
+  });
+
+  it('remove-filler: drops standalone filler, keeps filler embedded in real guidance', () => {
+    const input = [
+      'You are a helpful assistant.',
+      'Always follow best practices when touching the `src/payments` module specifically.',
+      'Write clean, readable, maintainable code.',
+    ].join('\n');
+    const out = byId('remove-filler').apply(input);
+    const lines = out.content.split('\n').filter(l => l.trim() !== '');
+    expect(lines.some(l => l.includes('helpful assistant'))).toBe(false);
+    expect(lines.some(l => l.includes('readable, maintainable'))).toBe(false);
+    // embedded filler inside a concrete instruction is preserved
+    expect(lines.some(l => l.includes('src/payments'))).toBe(true);
+  });
+});
+
+describe('selectOptimizers', () => {
+  it('defaults to all default-on optimizers', () => {
+    expect(selectOptimizers().map(o => o.id)).toEqual(OPTIMIZERS.map(o => o.id));
+  });
+  it('honors only and skip', () => {
+    expect(selectOptimizers(['whitespace']).map(o => o.id)).toEqual(['whitespace']);
+    expect(selectOptimizers(undefined, ['whitespace']).some(o => o.id === 'whitespace')).toBe(false);
+  });
+  it('throws on unknown optimizer id', () => {
+    expect(() => selectOptimizers(['nope'])).toThrow(/Unknown optimizer/);
+    expect(() => selectOptimizers(undefined, ['nope'])).toThrow(/Unknown optimizer/);
+  });
+});
+
+describe('meaningfulSignature', () => {
+  it('is invariant to blank lines, duplicates and filler', () => {
+    const a = 'Use the shared logger from src/utils/logger.ts everywhere.\n';
+    const b = [
+      '',
+      'You are a helpful assistant.',
+      'Use the shared logger from src/utils/logger.ts everywhere.',
+      '',
+      'Use the shared logger from src/utils/logger.ts everywhere.',
+      '',
+    ].join('\n');
+    expect(meaningfulSignature(a)).toBe(meaningfulSignature(b));
+  });
+  it('changes when a real instruction is removed', () => {
+    const a = 'Keep functions under 40 lines.\nValidate inputs with Zod.\n';
+    const b = 'Keep functions under 40 lines.\n';
+    expect(meaningfulSignature(a)).not.toBe(meaningfulSignature(b));
+  });
+});
+
+describe('optimize() integration', () => {
+  let repo: string;
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'cates-opt-'));
+    await mkdir(join(repo, '.github'), { recursive: true });
+    await writeFile(join(repo, INSTRUCTIONS), MESSY, 'utf-8');
+  });
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('reduces tokens losslessly and writes the file', async () => {
+    const result = await optimize({ repoPath: repo });
+
+    expect(result.totals.activeTokensSaved).toBeGreaterThan(0);
+    expect(result.efficiencyGainPct).toBeGreaterThan(0);
+    expect(result.totals.filesChanged).toBe(1);
+    expect(result.guarantee.noLossOfFunction).toBe(true);
+    expect(result.score.tokenEfficiencyFindingsAfter)
+      .toBeLessThan(result.score.tokenEfficiencyFindingsBefore);
+
+    const after = await readFile(join(repo, INSTRUCTIONS), 'utf-8');
+    // filler gone
+    expect(after).not.toMatch(/helpful assistant/i);
+    // exact duplicate collapsed to one
+    expect(after.split('reach for `let`').length - 1).toBe(1);
+    // meaningful instructions preserved
+    expect(after).toMatch(/Zod schemas/);
+    expect(after).toMatch(/explain every code change/); // forced verbosity NOT removed
+    // signature preservation holds against the original
+    expect(meaningfulSignature(MESSY)).toBe(meaningfulSignature(after));
+  });
+
+  it('keeps non-lossless work as remaining recommendations (TE004 stays)', async () => {
+    const result = await optimize({ repoPath: repo });
+    const te004 = result.remainingRecommendations.find(r => r.ruleIds.includes('TE004'));
+    expect(te004).toBeDefined();
+    expect(te004?.reason).toBeTruthy();
+  });
+
+  it('dry-run does not write but still reports the gain', async () => {
+    const result = await optimize({ repoPath: repo, dryRun: true });
+    expect(result.dryRun).toBe(true);
+    expect(result.totals.activeTokensSaved).toBeGreaterThan(0);
+    expect(result.notes.some(n => /Dry run/i.test(n))).toBe(true);
+    const onDisk = await readFile(join(repo, INSTRUCTIONS), 'utf-8');
+    expect(onDisk).toBe(MESSY); // untouched
+  });
+
+  it('writes a .orig backup when requested', async () => {
+    await optimize({ repoPath: repo, backup: true });
+    const backup = await readFile(join(repo, `${INSTRUCTIONS}.orig`), 'utf-8');
+    expect(backup).toBe(MESSY);
+    // second run must not clobber the backup
+    await optimize({ repoPath: repo, backup: true });
+    await expect(access(join(repo, `${INSTRUCTIONS}.orig`))).resolves.toBeUndefined();
+  });
+
+  it('respects --only to limit the optimizer set', async () => {
+    const result = await optimize({ repoPath: repo, only: ['whitespace'], dryRun: true });
+    // Only whitespace is in play; dedupe/filler are excluded entirely.
+    expect(result.optimizers.map(o => o.id)).toEqual(['whitespace']);
+  });
+
+  it('--skip remove-filler leaves filler in place (strict mechanical mode)', async () => {
+    const result = await optimize({ repoPath: repo, skip: ['remove-filler'], dryRun: true });
+    expect(result.optimizers.map(o => o.id)).not.toContain('remove-filler');
+    // The duplicate line still gets removed (dedupe is mechanical), saving tokens.
+    expect(result.totals.activeTokensSaved).toBeGreaterThan(0);
+  });
+
+  it('reuses a provided report when tokenizers match', async () => {
+    const report = await analyze({ repoPath: repo });
+    const result = await optimize({ repoPath: repo, report });
+    expect(result.notes.some(n => /Reused the provided CATES report/.test(n))).toBe(true);
+    expect(result.efficiencyGainPct).toBeGreaterThan(0);
+  });
+
+  it('re-analyzes when the provided report tokenizer differs', async () => {
+    const report = await analyze({ repoPath: repo, tokenizer: 'approx' });
+    const result = await optimize({ repoPath: repo, report, tokenizer: 'openai-cl100k' });
+    expect(result.tokenizer).toBe('openai-cl100k');
+    expect(result.notes.some(n => /tokenizer-consistent baseline/.test(n))).toBe(true);
+  });
+
+  it('never modifies structured config files (e.g. MCP JSON with duplicate lines)', async () => {
+    const mixed = await mkdtemp(join(tmpdir(), 'cates-struct-'));
+    try {
+      await mkdir(join(mixed, '.github'), { recursive: true });
+      await writeFile(join(mixed, INSTRUCTIONS), MESSY, 'utf-8');
+      // Two servers share a byte-identical, >20-char description line that the
+      // line-deduper WOULD remove if it (wrongly) ran on JSON — breaking config.
+      const mcp = [
+        '{',
+        '  "servers": {',
+        '    "alpha": {',
+        '      "command": "node",',
+        '      "description": "Query the project PostgreSQL database for schema info",',
+        '',
+        '',
+        '      "args": ["a.js"]',
+        '    },',
+        '    "beta": {',
+        '      "command": "node",',
+        '      "description": "Query the project PostgreSQL database for schema info",',
+        '      "args": ["b.js"]',
+        '    }',
+        '  }',
+        '}',
+        '',
+      ].join('\n');
+      await writeFile(join(mixed, '.mcp.json'), mcp, 'utf-8');
+
+      const result = await optimize({ repoPath: mixed });
+
+      // JSON is byte-for-byte untouched (both description lines survive).
+      const afterJson = await readFile(join(mixed, '.mcp.json'), 'utf-8');
+      expect(afterJson).toBe(mcp);
+      expect(afterJson.split('Query the project PostgreSQL').length - 1).toBe(2);
+      // The prose file was still optimized.
+      expect(result.totals.filesChanged).toBe(1);
+      expect(result.files.every(f => f.relativePath.endsWith('.md'))).toBe(true);
+      expect(result.notes.some(n => /structured config/.test(n))).toBe(true);
+    } finally {
+      await rm(mixed, { recursive: true, force: true });
+    }
+  });
+
+  it('returns an empty result when there are no config files', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'cates-empty-'));
+    try {
+      await writeFile(join(empty, 'notes.txt'), 'not a config file', 'utf-8');
+      const result = await optimize({ repoPath: empty });
+      expect(result.efficiencyGainPct).toBe(0);
+      expect(result.files).toEqual([]);
+      expect(result.notes.some(n => /No active coding-agent configuration/.test(n))).toBe(true);
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('renderOptimizationReport', () => {
+  let repo: string;
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'cates-rep-'));
+    await mkdir(join(repo, '.github'), { recursive: true });
+    await writeFile(join(repo, INSTRUCTIONS), MESSY, 'utf-8');
+  });
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  it('renders markdown with headline, guarantee and remaining sections', async () => {
+    const result = await optimize({ repoPath: repo, dryRun: true, backup: false });
+    const md = renderOptimizationReport(result, 'markdown');
+    expect(md).toMatch(/# CATES Optimization Report/);
+    expect(md).toMatch(/more token-efficient.*guaranteed no loss of function/);
+    expect(md).toMatch(/No loss of function/);
+    expect(md).toMatch(/Optimizations applied/);
+    expect(md).toMatch(/Remaining opportunities/);
+    expect(md.endsWith('\n')).toBe(true);
+  });
+
+  it('renders valid json', async () => {
+    const result = await optimize({ repoPath: repo, dryRun: true });
+    const json = renderOptimizationReport(result, 'json');
+    const parsed = JSON.parse(json);
+    expect(parsed.efficiencyGainPct).toBeGreaterThan(0);
+    expect(parsed.guarantee.noLossOfFunction).toBe(true);
+    expect(Array.isArray(parsed.files)).toBe(true);
+  });
+
+  it('reports "already optimal" when nothing can be saved', async () => {
+    const clean = await mkdtemp(join(tmpdir(), 'cates-clean-'));
+    try {
+      await mkdir(join(clean, '.github'), { recursive: true });
+      await writeFile(join(clean, INSTRUCTIONS), '# Title\n\nUse Vitest for tests.\n', 'utf-8');
+      const result = await optimize({ repoPath: clean, dryRun: true });
+      const md = renderOptimizationReport(result, 'markdown');
+      expect(md).toMatch(/already optimal/);
+    } finally {
+      await rm(clean, { recursive: true, force: true });
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
       include: ['src/**/*.ts', 'service/**/*.ts'],
       exclude: [
         'src/cli/**',
+        // The optimizer CLI is thin argument-parsing/glue around optimize();
+        // excluded for the same reason as src/cli/** (its logic is covered via
+        // tests/optimizer.test.ts driving optimize() and the report renderer).
+        'src/optimizer/cli.ts',
         // demo.ts is CLI orchestration that drives real GitHub clones
         // through analyze(); only its pure helpers are testable without
         // network. The exercised paths still get coverage via


### PR DESCRIPTION
Two additive, independently-gated capabilities.

cates-optimize (new binary): a separate, deliberately-invoked optimizer that consumes a CATES analysis and applies only lossless token-efficiency fixes (blank-line/whitespace hygiene, exact within-file duplicate removal, platform-default filler removal) to PROSE primitives. Guarantees no loss of function via a meaningful-instruction signature invariant plus an analyzer re-score (analyzeInMemory) for exact before/after parity, and emits an achievement report with the estimated % efficiency gain. Structured configs (JSON/YAML/shell) are never modified; nothing is auto-applied that could change behavior.

Experimental cache/output-shaping (CS001-CS005, OS001-OS005): opt-in, non-normative dimensions behind --experimental / --experimental-only / CATES_EXPERIMENTAL=1 / `experimental: true` in .cates.yml. Strictly isolated: zero scoring weight, excluded from conformance and CI gates, emitted only in a separate result.experimental channel. score.overall, grade, and conformance are byte-identical with the flag on or off (guardrail-tested). Wired into the analyzer, the standard (CATES-v1.0.md 4.2/4.5/5.4/8/9.9/9.10/10/11), and cates-optimize (advisory token impact, never auto-applied). Experimental rule IDs are SemVer-exempt.

280 tests pass (incl. isolation guardrails); coverage above CI thresholds.

# Description

<!-- What does this PR change and why? Link any related issues with `Fixes #N` / `Closes #N`. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing behavior to change)
- [ ] Documentation only
- [ ] Refactor / internal cleanup

## Checklist

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] `npm test` passes locally
- [ ] `npm run build` passes locally
- [ ] I added/updated tests for my change
- [ ] I updated documentation where relevant
- [ ] My commits follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials are included in this PR

## Notes for reviewers

<!-- Anything reviewers should pay particular attention to. -->
